### PR TITLE
Version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.1] - 2021-09-02
+
+### Changed in 1.0.1
+
+- Updated to Senzing API Server version 2.7.3 to add --debug option and fix
+  startup option logging.
+- Added debug logging for stream-loading operations if --debug enabled.
+- Updated build-info.properties so the Maven build timestamp is properly
+  filtered during build and token-replaced.
+
 ## [1.0.0] - 2021-07-08
 
 ### Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ LABEL Name="senzing/poc-api-server-builder" \
 
 # Build arguments.
 
-ARG SENZING_API_SERVER_VERSION=2.7.1
+ARG SENZING_API_SERVER_VERSION=2.7.3
 
 # Set environment variables.
 
@@ -28,7 +28,7 @@ ENV LD_LIBRARY_PATH=${SENZING_ROOT}/g2/lib:${SENZING_ROOT}/g2/lib/debian
 
 # Copy 'senzing-api-server.jar' to Builder step.
 
-COPY --from=senzing/senzing-api-server:2.7.1  "/app/senzing-api-server.jar" "/app/senzing-api-server.jar"
+COPY --from=senzing/senzing-api-server:2.7.3  "/app/senzing-api-server.jar" "/app/senzing-api-server.jar"
 
 # Install senzing-api-server.jar into maven repository.
 
@@ -62,7 +62,7 @@ ENV REFRESHED_AT=2021-08-10
 
 LABEL Name="senzing/poc-api-server" \
       Maintainer="support@senzing.com" \
-      Version="1.0.0"
+      Version="1.0.1"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[2.7.0, 3.0.0)</version>
+      <version>[2.7.2, 3.0.0)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[2.7.2, 3.0.0)</version>
+      <version>[2.7.3, 3.0.0)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>

--- a/src/main/java/com/senzing/poc/BuildInfo.java
+++ b/src/main/java/com/senzing/poc/BuildInfo.java
@@ -21,7 +21,7 @@ public class BuildInfo {
   static {
     String resource = "/com/senzing/poc/build-info.properties";
     String version = "UNKNOWN";
-    try (InputStream is = com.senzing.poc.BuildInfo.class.getResourceAsStream(resource))
+    try (InputStream is = BuildInfo.class.getResourceAsStream(resource))
     {
       Properties buildProps = new Properties();
       buildProps.load(is);

--- a/src/main/java/com/senzing/poc/services/BulkDataStreamSupport.java
+++ b/src/main/java/com/senzing/poc/services/BulkDataStreamSupport.java
@@ -10,6 +10,7 @@ import com.senzing.io.TemporaryDataCache;
 import com.senzing.poc.server.SzPocProvider;
 import com.senzing.util.AccessToken;
 import com.senzing.util.JsonUtils;
+import com.senzing.util.LoggingUtilities;
 import com.senzing.util.Timers;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 
@@ -133,6 +134,11 @@ public interface BulkDataStreamSupport
 
       String charset = bulkDataSet.getCharacterEncoding();
 
+      if (LoggingUtilities.isDebugLogging()) {
+        System.out.println(
+            "[BulkDataStreamSupport] BULK DATA CHARACTER ENCODING: " + charset);
+      }
+
       String loadId = (explicitLoadId == null)
           ? formatLoadId(dataCache, fileMetaData) : explicitLoadId;
 
@@ -150,6 +156,13 @@ public interface BulkDataStreamSupport
                                                      entityTypeMap,
                                                      loadId);
         bulkDataSet.setFormat(recordReader.getFormat());
+
+        if (LoggingUtilities.isDebugLogging()) {
+          System.out.println(
+              "[BulkDataStreamSupport] BULK DATA FORMAT: "
+                  + bulkDataSet.getFormat());
+        }
+
         bulkLoadResult.setCharacterEncoding(charset);
         bulkLoadResult.setMediaType(bulkDataSet.getFormat().getMediaType());
 
@@ -183,6 +196,13 @@ public interface BulkDataStreamSupport
             if ((!done)
                 && (resolvedDS == null || resolvedDS.trim().length() == 0
                 || resolvedET == null || resolvedET.trim().length() == 0)) {
+
+              if (LoggingUtilities.isDebugLogging()) {
+                System.out.println(
+                    "[BulkDataStreamSupport] INCOMPLETE RECORD NOT SENT: "
+                        + JsonUtils.toJsonText(record));
+              }
+
               bulkLoadResult.trackIncompleteRecord(resolvedDS, resolvedET);
 
             } else {
@@ -204,6 +224,16 @@ public interface BulkDataStreamSupport
                 String[] trackParams = {resolvedDS, resolvedET};
                 trackingList.add(trackParams);
                 recordBytes = null;
+
+                if (LoggingUtilities.isDebugLogging()) {
+                  System.out.println(
+                      "[BulkDataStreamSupport] BATCHING RECORD " + batchCount
+                      + " OF " + maxBatchCount + ": " + recordText);
+                  System.out.println(
+                      "[BulkDataStreamSupport] BATCH SIZE / MAX: "
+                          + batchBytes.size() + " bytes / "
+                          + MAXIMUM_BATCH_BYTES + " bytes");
+                }
               }
 
               // now check if we are sending the current batch
@@ -229,6 +259,12 @@ public interface BulkDataStreamSupport
                 // send the batch
                 this.sendingAsyncMessage(timers, LOAD_QUEUE_NAME);
                 try {
+                  if (LoggingUtilities.isDebugLogging()) {
+                    System.out.println(
+                        "[BulkDataStreamSupport] SENDING MESSAGE "
+                            + messageBody);
+                  }
+
                   // send the info on the async queue
                   loadSink.send(message, (exception, msg) -> {
                     logFailedAsyncLoad(exception, msg);
@@ -286,6 +322,15 @@ public interface BulkDataStreamSupport
                   prefix = ",";
                   String[] trackParams = {resolvedDS, resolvedET};
                   trackingList.add(trackParams);
+                  if (LoggingUtilities.isDebugLogging()) {
+                    System.out.println(
+                        "[BulkDataStreamSupport] BATCHING RECORD " + batchCount
+                            + " OF " + maxBatchCount + ": " + recordText);
+                    System.out.println(
+                        "[BulkDataStreamSupport] BATCH SIZE / MAX: "
+                            + batchBytes.size() + " bytes / "
+                            + MAXIMUM_BATCH_BYTES + " bytes");
+                  }
                 }
               }
             }

--- a/src/main/resources/com/senzing/poc/build-info.properties
+++ b/src/main/resources/com/senzing/poc/build-info.properties
@@ -1,2 +1,2 @@
 Maven-Version=${project.version}
-Maven-Timestamp=${timestamp}
+Maven-Timestamp=${maven.build.timestamp}


### PR DESCRIPTION
- Updated to Senzing API Server version 2.7.3 to add --debug option and fix  startup option logging.

- Added debug logging for stream-loading operations if --debug enabled.

- Updated build-info.properties so the Maven build timestamp is properly filtered during build and token-replaced.
