### PR TITLE
Fixed typo preventing startup with Rabbit MQ options due to invalid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2021-10-06
+
+### Changed in 1.0.3
+
+- Fixed typo causing a conflict between each Rabbit MQ command-line option and
+  every other Rabbit MQ command-line option. 
+
 ## [1.0.2] - 2021-09-08
 
 ### Changed in 1.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[2.7.4, 3.0.0)</version>
+      <version>[2.7.4, 3.0.0-SNAPSHOT)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>

--- a/src/main/java/com/senzing/poc/server/SzPocServerOption.java
+++ b/src/main/java/com/senzing/poc/server/SzPocServerOption.java
@@ -810,7 +810,7 @@ public enum SzPocServerOption implements CommandLineOption<SzPocServerOption>
 
       Set<SzPocServerOption> sqsLoadOptions = Set.of(SQS_LOAD_URL);
 
-      // enforce that we only have one info queue
+      // enforce that we only have one load queue
       for (SzPocServerOption option: kafkaLoadOptions) {
         Set<CommandLineOption> conflictSet = conflictMap.get(option);
         conflictSet.addAll(rabbitLoadOptions);
@@ -818,7 +818,7 @@ public enum SzPocServerOption implements CommandLineOption<SzPocServerOption>
       }
       for (SzPocServerOption option: rabbitLoadOptions) {
         Set<CommandLineOption> conflictSet = conflictMap.get(option);
-        conflictSet.addAll(rabbitLoadOptions);
+        conflictSet.addAll(kafkaLoadOptions);
         conflictSet.addAll(sqsLoadOptions);
       }
       for (SzPocServerOption option: sqsLoadOptions) {


### PR DESCRIPTION
Fixed typo causing a conflict between each Rabbit MQ command-line option and every other Rabbit MQ command-line option. 
