### PR TITLE
Version 1.1.0 which updates to Senzing API Server 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2021-12-01
+
+### Changed in 1.1.0
+
+- Updated to `senzing-api-server` version 2.8.0 using `senzings-common-java`
+- Now masks the value of the Rabbit MQ password in logs
+
 ## [1.0.3] - 2021-10-06
 
 ### Changed in 1.0.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ENV REFRESHED_AT=2021-08-22
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="1.0.2"
+      Version="1.1.0"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.1.0</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[2.7.4, 3.0.0-SNAPSHOT)</version>
+      <version>[2.8.0, 3.0.0-SNAPSHOT)</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>

--- a/src/main/java/com/senzing/poc/server/SzPocServer.java
+++ b/src/main/java/com/senzing/poc/server/SzPocServer.java
@@ -10,6 +10,8 @@ import com.senzing.api.services.SzMessageSink;
 import com.senzing.cmdline.CommandLineOption;
 import com.senzing.cmdline.CommandLineUtilities;
 import com.senzing.cmdline.CommandLineValue;
+import com.senzing.cmdline.CommandLineException;
+import com.senzing.cmdline.DeprecatedOptionWarning;
 import com.senzing.poc.model.SzPocMeta;
 import com.senzing.poc.model.SzPocServerInfo;
 import com.senzing.poc.model.SzPocVersionInfo;
@@ -355,12 +357,16 @@ public class SzPocServer extends SzApiServer implements SzPocProvider {
    *
    * @return The {@link Map} describing the command-line arguments.
    */
-  protected static Map<CommandLineOption, Object> parseCommandLine(String[] args) {
+  protected static Map<CommandLineOption, Object> parseCommandLine(
+      String[] args, List<DeprecatedOptionWarning> deprecationWarnings)
+      throws CommandLineException
+  {
     Map<CommandLineOption, CommandLineValue> optionValues
         = CommandLineUtilities.parseCommandLine(
         SzPocServerOption.class,
         args,
-        SzPocServerOption.PARAMETER_PROCESSOR);
+        SzPocServerOption.PARAMETER_PROCESSOR,
+        deprecationWarnings);
 
     // create a result map
     Map<CommandLineOption, Object> result = new LinkedHashMap<>();

--- a/src/main/java/com/senzing/poc/server/SzPocServerOption.java
+++ b/src/main/java/com/senzing/poc/server/SzPocServerOption.java
@@ -3,8 +3,7 @@ package com.senzing.poc.server;
 import java.util.*;
 
 import com.senzing.api.server.SzApiServerOption;
-import com.senzing.cmdline.CommandLineOption;
-import com.senzing.cmdline.ParameterProcessor;
+import com.senzing.cmdline.*;
 
 import static com.senzing.util.CollectionUtilities.recursivelyUnmodifiableMap;
 import static com.senzing.api.server.mq.KafkaEndpoint.*;
@@ -15,7 +14,8 @@ import static com.senzing.poc.server.SzPocServerConstants.*;
 /**
  * Describes the command-line options for {@link SzPocServer}.
  */
-public enum SzPocServerOption implements CommandLineOption<SzPocServerOption>
+public enum SzPocServerOption
+    implements CommandLineOption<SzPocServerOption, SzApiServerOption>
 {
   /**
    * <p>
@@ -903,6 +903,7 @@ public enum SzPocServerOption implements CommandLineOption<SzPocServerOption>
      */
     public Object process(CommandLineOption option,
                           List<String>      params)
+      throws BadOptionParametersException
     {
       // check if an instance of SzApiServerOption
       if (option instanceof SzApiServerOption) {


### PR DESCRIPTION
- Updated to `senzing-api-server` version 2.8.0 using `senzings-common-java`
- Now masks the value of the Rabbit MQ password in logs
