### PR TITLE
Version 1.1.0 update to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ LABEL Name="senzing/senzing-poc-server-builder" \
 
 # Build arguments.
 
-ARG SENZING_API_SERVER_VERSION=2.7.5
+ARG SENZING_API_SERVER_VERSION=2.8.0
 
 # Set environment variables.
 


### PR DESCRIPTION
Dockerfile updated so that it depends on version 2.8.0 of the senzing-api-server instead of version 2.7.5