### PR TITLE
Version 1.1.0 -- one more time -- Dockerfile changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV LD_LIBRARY_PATH=${SENZING_ROOT}/g2/lib:${SENZING_ROOT}/g2/lib/debian
 
 # Copy 'senzing-api-server.jar' to Builder step.
 
-COPY --from=senzing/senzing-api-server:2.7.5 "/app/senzing-api-server.jar" "/app/senzing-api-server.jar"
+COPY --from=senzing/senzing-api-server:2.8.0 "/app/senzing-api-server.jar" "/app/senzing-api-server.jar"
 
 # Install senzing-api-server.jar into maven repository.
 


### PR DESCRIPTION
Found line in Dockerfile still referencing `senzing-api-server:2.7.5` and updated to version `2.8.0`