### PR TITLE
Version 3.2.0 of the POC Server including update to Senzing API Server 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     per Issue #61
   - Adds "how entity" support (both by record ID and entity ID)
   - Adds "get virtual entity" support
-  - Adds `detailLevel` support.
-  - Adds `SzFeatureMode.ATTRIBUTED` support.
-  - See `CHANGELOG.md` from `Senzing/senzing-api-server` for further details.
-- Updated dependency 
+  - Adds `detailLevel` support
+  - Adds `SzFeatureMode.ATTRIBUTED` support
+  - See `CHANGELOG.md` from `Senzing/senzing-api-server` for further details
+- Updated dependencies to match the `senzing-api-server` dependency versions
 
 ## [3.1.1] - 2022-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2022-08-18
+
+### Changed in 3.2.0
+
+- Updated to `senzing-api-server` version `3.3.0` including all changes provided
+  by that:
+  - Adds support for `SENZING_ENGINE_CONFIGURATION_JSON` environment variable
+    per Issue #61
+  - Adds "how entity" support (both by record ID and entity ID)
+  - Adds "get virtual entity" support
+  - Adds `detailLevel` support.
+  - Adds `SzFeatureMode.ATTRIBUTED` support.
+  - See `CHANGELOG.md` from `Senzing/senzing-api-server` for further details.
+- Updated dependency 
+
 ## [3.1.1] - 2022-07-20
 
 ### Changed in 3.1.1

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.1.0</version>
+  <version>3.2.0</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[3.0.0, 3.999.999]</version>
+      <version>[3.3.0, 3.999.999]</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
@@ -21,78 +21,78 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.45.v20220203</version>
+      <version>9.4.48.v20220622</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -103,37 +103,37 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.35</version>
+      <version>2.36</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.2.1</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
-      <version>1.8</version>
+      <version>1.9.0</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>65.1</version>
+      <version>71.1</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.30.1</version>
+       <version>3.39.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing POC REST API
-  version: "3.0.0"git st
+  version: "3.2.0"
   description: >-
     This is the Senzing POC REST API.  This API is <b>NOT</b> maintained for
     backwards compatibility.  This API extends the
@@ -1044,6 +1044,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/dataSourceCodePathParam'
         - $ref: '#/components/parameters/recordIdPathParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/withFeatureStatsQueryParam'
         - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
@@ -1095,6 +1096,7 @@ paths:
         - $ref: '#/components/parameters/withRelationshipsQueryParam'
         - $ref: '#/components/parameters/whyWithFeatureStatsQueryParam'
         - $ref: '#/components/parameters/whyWithInternalFeaturesQueryParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/forceMinimalQueryParam'
         - $ref: '#/components/parameters/withRawQueryParam'
@@ -1111,6 +1113,49 @@ paths:
             default:
               schema:
                 $ref: '#/components/schemas/SzWhyEntityResponse'
+        '404':
+          description: If data source or record ID are not found.
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /data-sources/{dataSourceCode}/records/{recordId}/entity/how:
+    get:
+      tags:
+        - Entity Data
+      summary: >-
+        Returns an analysis of how the entity for the record with the
+        respective data source code and record ID resolved.
+      description: |
+        This operation provides an anlysis of how the records in an entity
+        resolved.  The subject entity is the one containing the record
+        identified by the data source code and record ID in the request path.
+      operationId: howEntityByRecordID
+      parameters:
+        - $ref: '#/components/parameters/dataSourceCodePathParam'
+        - $ref: '#/components/parameters/recordIdPathParam'
+        - $ref: '#/components/parameters/withRawQueryParam'
+      responses:
+        '200':
+          description: Successul response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzHowEntityResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzHowEntityResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzHowEntityResponse'
         '404':
           description: If data source or record ID are not found.
           content:
@@ -1250,6 +1295,7 @@ paths:
                 "WORK_ADDR_STATE:CA"
               ]
         - $ref: '#/components/parameters/includeOnlyQueryParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/withFeatureStatsQueryParam'
         - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
@@ -1313,6 +1359,7 @@ paths:
       operationId: searchEntitiesByPost
       parameters:
         - $ref: '#/components/parameters/includeOnlyQueryParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/withFeatureStatsQueryParam'
         - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
@@ -1391,8 +1438,8 @@ paths:
 
         **NOTE:** Bear in mind that entity ID's are transient and may be
         recycled or repurposed as new records are loaded and entities resolve,
-        unresolve and re-resolve.  An alternative way to identify a record is
-        by one of its composite records using
+        unresolve and re-resolve.  An alternative way to identify an entity is
+        by one of its constituent records using
         `GET /data-sources/{dataSourceCode}/records/{recordId}/entity`.
       operationId: getEntityByEntityId
       parameters:
@@ -1404,6 +1451,7 @@ paths:
         schema:
           type: integer
           format: int64
+      - $ref: '#/components/parameters/detailLevelQueryParam'
       - $ref: '#/components/parameters/featureModeQueryParam'
       - $ref: '#/components/parameters/withFeatureStatsQueryParam'
       - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
@@ -1451,8 +1499,8 @@ paths:
 
         **NOTE:** Bear in mind that entity ID's are transient and may be
         recycled or repurposed as new records are loaded and entities resolve,
-        unresolve and re-resolve.  An alternative way to identify a record is
-        by one of its composite records using
+        unresolve and re-resolve.  An alternative way to identify an entity is
+        by one of its constituent records using
         `GET /data-sources/{dataSourceCode}/records/{recordId}/entity/why`.
       operationId: whyEntityByEntityID
       parameters:
@@ -1467,6 +1515,7 @@ paths:
         - $ref: '#/components/parameters/withRelationshipsQueryParam'
         - $ref: '#/components/parameters/whyWithFeatureStatsQueryParam'
         - $ref: '#/components/parameters/whyWithInternalFeaturesQueryParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/forceMinimalQueryParam'
         - $ref: '#/components/parameters/withRawQueryParam'
@@ -1483,6 +1532,62 @@ paths:
             default:
               schema:
                 $ref: '#/components/schemas/SzWhyEntityResponse'
+        '404':
+          description: If entity ID is not found.
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /entities/{entityId}/how:
+    get:
+      tags:
+        - Entity Data
+      summary: >-
+        Returns an analysis of how the entity for the respective
+        entity ID resolved.
+      description: |
+        This operation provides an anlysis of how the records in an entity
+        resolved.  The subject entity is identified by the entity ID in the
+        request path.
+
+        **NOTE:** Bear in mind that entity ID's are transient and may be
+        recycled or repurposed as new records are loaded and entities resolve,
+        unresolve and re-resolve.  An alternative way to identify an entity is
+        by one of its constituent records using
+        `GET /data-sources/{dataSourceCode}/records/{recordId}/entity/how`.
+      operationId: howEntityByEntityID
+      parameters:
+        - name: entityId
+          description: >-
+            The unique numeric ID that identifies the entity for which to
+            perform the analysis.
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - $ref: '#/components/parameters/withRawQueryParam'
+      responses:
+        '200':
+          description: Successul response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzHowEntityResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzHowEntityResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzHowEntityResponse'
         '404':
           description: If entity ID is not found.
           content:
@@ -1541,6 +1646,7 @@ paths:
         - $ref: '#/components/parameters/withRelationshipsQueryParam'
         - $ref: '#/components/parameters/whyWithFeatureStatsQueryParam'
         - $ref: '#/components/parameters/whyWithInternalFeaturesQueryParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/forceMinimalQueryParam'
         - $ref: '#/components/parameters/withRawQueryParam'
@@ -1629,6 +1735,7 @@ paths:
         - $ref: '#/components/parameters/withRelationshipsQueryParam'
         - $ref: '#/components/parameters/whyWithFeatureStatsQueryParam'
         - $ref: '#/components/parameters/whyWithInternalFeaturesQueryParam'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
         - $ref: '#/components/parameters/featureModeQueryParam'
         - $ref: '#/components/parameters/forceMinimalQueryParam'
         - $ref: '#/components/parameters/withRawQueryParam'
@@ -1706,6 +1813,119 @@ paths:
                 $ref: '#/components/schemas/SzReevaluateResponse'
         '404':
           description: If data source or record ID are not found.
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzErrorResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /virtual-entities:
+    get:
+      tags:
+        - Entity Data
+      summary: >-
+        Builds a virtual entity by simulating the resolution of the records
+        identified by the specified record ID parameters.
+      description: |
+        This operation simulates the resolution of the one or more specified
+        records into a single entity and returns the simulated "virtual"
+        entity.  The subject records are identified by data source code and
+        record ID pairs.
+      operationId: getVirtualEntityByRecordIds
+      parameters:
+        - name: r
+          description: >-
+            Repeating query parameter containing encoded `SzRecordId`
+            definitions that identify records to be inclued in the resultant
+            virtual entity.  At least one record identifier is required.  If
+            both this parameter and the `records` parameter are specified then
+            the values are merged.
+            **NOTE**: An encoded `SzRecordId` can EITHER be encoded as JSON or
+            as a delimited string where the first character is the delimiter and
+            the remainer is parsed as a data source prefix (up to the second
+            occurrence of the delimiter) and a record ID suffix (all characters
+            after the second occurrence of the delimiter).  For example:
+            `{"src":"PEOPLE","id":"12345ABC"}` or `:PEOPLE:12345ABC`.
+          in: query
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SzRecordIdentifier'
+          examples:
+            noRecordsExample:
+              $ref: '#/components/examples/noRecordsExample'
+            singleByDelimitedRecordIdExample:
+              $ref: '#/components/examples/singleRecordByDelimitedRecordIdExample'
+            multipleByDelimitedRecordIdExample:
+              $ref: '#/components/examples/multipleRecordsByDelimitedRecordIdExample'
+            singleByJsonRecordIdExample:
+              $ref: '#/components/examples/singleRecordByJsonRecordIdExample'
+            multipleByJsonRecordIdExample:
+              $ref: '#/components/examples/multipleRecordsByJsonRecordIdExample'
+            multipleByMixedRecordIdExample:
+              $ref: '#/components/examples/multipleRecordsByMixedRecordIdExample'
+        - name: records
+          description: >-
+            Singular query parameter containing multiple encoded `SzRecordId`
+            definitions that identify records to be inclued in the resultant
+            virtual entity as a JSON array or a simple comma-separated array.
+            At least one record identifier is required.  If both this parameter
+            and the `r` parameter are specified then the values are merged.
+            **NOTE**: An encoded `SzRecordId` can EITHER be encoded as JSON or
+            as a delimited string where the first character is the delimiter and
+            the remainer is parsed as a data source prefix (up to the second
+            occurrence of the delimiter) and a record ID suffix (all characters
+            after the second occurrence of the delimiter).  For example:
+            `{"src":"PEOPLE","id":"12345ABC"}` or `:PEOPLE:12345ABC`.
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/SzRecordIdentifiers'
+          examples:
+            noRecordsExample:
+              $ref: '#/components/examples/noRecordsArrayExample'
+            singleByDelimitedRecordIdExample:
+              $ref: '#/components/examples/singleRecordByDelimitedRecordIdArrayExample'
+            multipleByDelimitedRecordIdExample:
+              $ref: '#/components/examples/multipleRecordsByDelimitedRecordIdArrayExample'
+            singleByJsonRecordIdExample:
+              $ref: '#/components/examples/singleRecordByJsonRecordIdArrayExample'
+            multipleByJsonRecordIdExample:
+              $ref: '#/components/examples/multipleRecordsByJsonRecordIdArrayExample'
+            multipleByMixedRecordIdExample:
+              $ref: '#/components/examples/multipleRecordsByMixedRecordIdArrayExample'
+        - $ref: '#/components/parameters/detailLevelQueryParam'
+        - $ref: '#/components/parameters/featureModeQueryParam'
+        - $ref: '#/components/parameters/withFeatureStatsQueryParam'
+        - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
+        - $ref: '#/components/parameters/forceMinimalQueryParam'
+        - $ref: '#/components/parameters/withRawQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzVirtualEntityResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzVirtualEntityResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzVirtualEntityResponse'
+        '400':
+          description: >-
+            If no record identifies are specified via the query parameters.
+            Also, if any of the identified records cannot be found.
           content:
             application/json; charset=UTF-8:
               schema:
@@ -1797,6 +2017,8 @@ paths:
         description: >-
             The maximum number of degrees to look for a path from the first
             entity to the last entity.  This defaults to `3` if not specified.
+            If specified, the value must be greater-than zero (0) since a path
+            cannot exist at zero degrees of separation.
         in: query
         required: false
         schema:
@@ -1918,6 +2140,7 @@ paths:
           requireMultipleDataSourcesExample:
             summary: Require multiple data sources
             value: [ VIPS, PARTNERS ]
+      - $ref: '#/components/parameters/detailLevelQueryParam'
       - $ref: '#/components/parameters/featureModeQueryParam'
       - $ref: '#/components/parameters/withFeatureStatsQueryParam'
       - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
@@ -1987,8 +2210,8 @@ paths:
           records that are part of the resolved entities to avoid.  At least
           one entity identifier is required.  If both this parameter and the
           `entities` parameter are specified then the values are merged.
-          NOTE: An encoded SzRecordId can EITHER be encoded as JSON or as a
-          delimited string where the first character is the delimiter and the
+          **NOTE**: An encoded `SzRecordId` can EITHER be encoded as JSON or as
+          a delimited string where the first character is the delimiter and the
           remainder is parsed as a data source prefix (up to the second
           occurrence of the delimiter) and a record ID suffix (all characters
           after the second occurrence of the delimiter).  For example:
@@ -2059,6 +2282,10 @@ paths:
         description: >-
             The maximum number of degrees to look for a path between the
             specified entities.  If not specified, this defaults to `3`.
+            Unlike `GET /entity-paths/` the value here may be zero (0) which
+            allows the caller to specify a list of entities and simply
+            "build out" the network around each to a maximum number of degrees
+            and up to a maximum number of entities.
         in: query
         required: false
         schema:
@@ -2093,6 +2320,7 @@ paths:
           format: int32
           minimum: 0
           default: 1000
+      - $ref: '#/components/parameters/detailLevelQueryParam'
       - $ref: '#/components/parameters/featureModeQueryParam'
       - $ref: '#/components/parameters/withFeatureStatsQueryParam'
       - $ref: '#/components/parameters/withInternalFeaturesQueryParam'
@@ -2113,9 +2341,9 @@ paths:
                 $ref: '#/components/schemas/SzEntityNetworkResponse'
         '400':
           description: >-
-            If the 'e' entity identifiers parameter is missing or if any of the
-            parameters are not formatted as expected.  Also, if any of the
-            identified entities or records cannot be found.
+            If no entity identifiers are specified or if any of the parameters
+            are not formatted as expected.  Also, if any of the identified
+            entities or records cannot be found.
           content:
             application/json; charset=UTF-8:
               schema:
@@ -3392,6 +3620,9 @@ components:
     noEntitiesExample:
       summary: No entities specified
       value: [ ]
+    noRecordsExample:
+      summary: No records specified
+      value: [ ]
     singleEntityByEntityIdExample:
       summary: Single entity by entity ID
       value: [ 987654 ]
@@ -3401,20 +3632,38 @@ components:
     singleEntityByDelimitedRecordIdExample:
       summary: Single entity by delimiter-encoded record ID
       value: [ ":CUSTOMERS:GHI789" ]
+    singleRecordByDelimitedRecordIdExample:
+      summary: Single record by delimiter-encoded record ID
+      value: [ ":CUSTOMERS:GHI789" ]
     multipleEntitiesByDelimitedRecordIdExample:
       summary: Multiple entities by delimiter-encoded record ID
+      value: [ ":CUSTOMERS:GHI789", ":EMPLOYEES:JKL321" ]
+    multipleRecordsByDelimitedRecordIdExample:
+      summary: Multiple records by delimiter-encoded record ID
       value: [ ":CUSTOMERS:GHI789", ":EMPLOYEES:JKL321" ]
     singleEntityByJsonRecordIdExample:
       summary: Single entity by JSON-encoded record ID
       value: [ '{"src":"CUSTOMERS","id":"GHI789"}' ]
+    singleRecordByJsonRecordIdExample:
+      summary: Single record by JSON-encoded record ID
+      value: [ '{"src":"CUSTOMERS","id":"GHI789"}' ]
     multipleEntitiesByJsonRecordIdExample:
       summary: Multiple entities by JSON-encoded record ID
+      value: [ '{"src":"CUSTOMERS","id":"GHI789"}', '{"src":"EMPLOYEES","id":"JKL321"}' ]
+    multipleRecordsByJsonRecordIdExample:
+      summary: Multiple records by JSON-encoded record ID
       value: [ '{"src":"CUSTOMERS","id":"GHI789"}', '{"src":"EMPLOYEES","id":"JKL321"}' ]
     multipleEntitiesByMixedRecordIdExample:
       summary: Multiple entities by mixed-encoded record ID
       value: [ ":CUSTOMERS:GHI789", '{"src":"EMPLOYEES","id":"JKL321"}' ]
+    multipleRecordsByMixedRecordIdExample:
+      summary: Multiple records by mixed-encoded record ID
+      value: [ ":CUSTOMERS:GHI789", '{"src":"EMPLOYEES","id":"JKL321"}' ]
     noEntitiesArrayExample:
       summary: No entities specified
+      value:
+    noRecordsArrayExample:
+      summary: No records specified
       value:
     singleEntityByEntityIdArrayExample:
       summary: Single entity by entity ID
@@ -3425,17 +3674,32 @@ components:
     singleEntityByDelimitedRecordIdArrayExample:
       summary: Single entity by delimiter-encoded record ID
       value: '[":CUSTOMERS:GHI789"]'
+    singleRecordByDelimitedRecordIdArrayExample:
+      summary: Single record by delimiter-encoded record ID
+      value: '[":CUSTOMERS:GHI789"]'
     multipleEntitiesByDelimitedRecordIdArrayExample:
       summary: Multiple entities by delimiter-encoded record ID
+      value: '[":CUSTOMERS:GHI789",":EMPLOYEES:JKL321"]'
+    multipleRecordsByDelimitedRecordIdArrayExample:
+      summary: Multiple records by delimiter-encoded record ID
       value: '[":CUSTOMERS:GHI789",":EMPLOYEES:JKL321"]'
     singleEntityByJsonRecordIdArrayExample:
       summary: Single entity by JSON-encoded record ID
       value: '[{"src":"CUSTOMERS","id":"GHI789"}]'
+    singleRecordByJsonRecordIdArrayExample:
+      summary: Single record by JSON-encoded record ID
+      value: '[{"src":"CUSTOMERS","id":"GHI789"}]'
     multipleEntitiesByJsonRecordIdArrayExample:
       summary: Multiple entities by JSON-encoded record ID
       value: '[{"src":"CUSTOMERS","id":"GHI789"},{"src":"EMPLOYEES","id":"JKL321"}]'
+    multipleRecordsByJsonRecordIdArrayExample:
+      summary: Multiple records by JSON-encoded record ID
+      value: '[{"src":"CUSTOMERS","id":"GHI789"},{"src":"EMPLOYEES","id":"JKL321"}]'
     multipleEntitiesByMixedRecordIdArrayExample:
       summary: Multiple entities by mixed-encoded record ID
+      value: '[":CUSTOMERS:GHI789",{"src":"EMPLOYEES","id":"JKL321"}]'
+    multipleRecordsByMixedRecordIdArrayExample:
+      summary: Multiple records by mixed-encoded record ID
       value: '[":CUSTOMERS:GHI789",{"src":"EMPLOYEES","id":"JKL321"}]'
     ssnSearchExample:
       summary: Social security number
@@ -3638,12 +3902,16 @@ components:
              information for related entities with the `partial` property of the
              `SzRelatedEntity` instances set to `true`.  Obtaining additional
              information requires subsequent API calls.
-          * `FULL` - Include full data on the first-degree related entities.
-             This option obtains entity network at one degree for the requested
-             entity and will fully populate up to 1000 related entities and sets
-             the `partial` property of those `SzRelatedEntity` instances to
-             `false`.  Related entities beyond the first 1000 will be left
-             incomplete and have their `partial` property will be set to `true`.
+          * `FULL` - Include full data on the first-degree related entities
+             according to the `featureMode` and `detailLevel` **unless**
+             `forceMinimal` is `true`.  This option obtains the entity network
+             at one degree for the requested entity and will populate up to 1000
+             related entities as much as possible with respect to the
+             `featureMode` and `detailLevel`.  Related entities beyond the first
+             1000 will be left incomplete and have their `partial` property set
+             to `true` regardless of the `detailLevel` and `featureMode`.  If
+             this value is specified along with `forceMinimal=true` then
+             `PARTIAL` is used instead.
       schema:
         default: PARTIAL
         $ref: '#/components/schemas/SzRelationshipMode'
@@ -3662,12 +3930,56 @@ components:
                                multiple values that are near duplicates then
                                only one value is included and the others are
                                suppressed.
-          * `WITH_DUPLICATES` - Group near-duplicate feature values and return
-                                a representative value along with its near
-                                duplicate values.
+          * `WITH_DUPLICATES` - ** (default value) ** Group near-duplicate
+                                feature values and return a representative value
+                                along with its near duplicate values.
+          * `ATTRIBUTED` - Same as `WITH_DUPLICATES` but with record-level
+                           references attributing each feature to the record(s)
+                           that provided it for the entity along with any
+                           usage type that might have been associated with the
+                           feature at the record level.
       schema:
         default: WITH_DUPLICATES
         $ref: '#/components/schemas/SzFeatureMode'
+    detailLevelQueryParam:
+      in: query
+      name: detailLevel
+      required: false
+      description: >-
+        Specifies the level of detail desired for the entity data.  Details for
+        features of entities as well as the related entities of entities are
+        controlled by `featureMode`, `withInternalFeatures`, and
+        `withFeatureStats`.  If not specified the value defaults to `VERBOSE`.
+        Possible values are:
+          * `MINIMAL` - The entities returned will include at most their
+                        entity ID's as well as identifiers for their
+                        constituent records (i.e.: data source code and record
+                        ID for each record).  This detail level is optimized for
+                        the fastest possible processing time.
+          * `BRIEF` - Builds upon `MINIMAL` to add the entity name and related
+                      entity match info when related entity match info when
+                      related entities are included.  This detail level aims to
+                      maintain as much speed as possible while providing names
+                      and relationship information for rendering a graph.
+          * `SUMMARY` - Identical to `BRIEF` except that individual record
+                        identifier information is excluded, leaving only the
+                        record summary (i.e.: a record count by data source
+                        code).  This reduces the size of the JSON document for
+                        large entities with thousands of records.  It may take
+                        longer to process than `BRIEF` but less data is
+                        returned as well, speeding up network transfer times.
+          * `VERBOSE` - Combines `BRIEF` and `SUMMARY` and then adds the
+                        original JSON data for each record, the record-level
+                        matching info, as well as formatted record data.  NOTE:
+                        the record-level matching info returned via "how" and
+                        "why" is often more useful than that embedded in the
+                        entity.  Further, the formatted record data, while
+                        readable, is not formatted according to locale (i.e.:
+                        address, name and date formatting may not appear as
+                        expected to a user).
+      schema:
+        default: VERBOSE
+        $ref: '#/components/schemas/SzDetailLevel'
     withRelationshipsQueryParam:
       in: query
       name: withRelationships
@@ -3772,12 +4084,16 @@ components:
       name: forceMinimal
       required: false
       description: >-
-        Whether or not to force the minimum entity detail in the response which
-        may consist of nothing more than an entity ID.  This provides the
-        fastest response to an entity query operation because no additional data
-        needs to be retrieved other than what is directly accessible.  This
-        overrules other parameters governing the retrieval of features or
-        related entities.
+        Whether (or not) to force the minimum entity detail in the response
+        which will consist of nothing more than an entity ID and record
+        identifying information (i.e.: data source code and record ID) for each
+        constituent record of an entity.  Unlike `detailLevel=MINIMAL` setting
+        this to `true` precludes the addition of feature information via other
+        parameters.  Setting this to `true` provides the fastest response to an
+        entity query operation because no additional data needs to be retrieved
+        other than what is directly accessible.  Setting this parameter to
+        `true` overrules other parameters governing the retrieval of features
+        or related entities.
       schema:
         type: boolean
         default: false
@@ -3987,7 +4303,7 @@ components:
         - type: object
           additionalProperties: {}
     SzLicenseResponseData:
-      description: >
+      description: >-
         Represents the data segment included with an `SzLicenseResponse`
       type: object
       properties:
@@ -4185,6 +4501,16 @@ components:
           properties:
             data:
               $ref: '#/components/schemas/SzEntityData'
+    SzVirtualEntityResponse:
+      description: >-
+        The response describing a simulated virtual entity and possibly its
+        related entities.
+      allOf:
+        - $ref: '#/components/schemas/SzResponseWithRawData'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/SzVirtualEntityData'
     SzAttributeSearchResponseData:
       description: >-
         Describes the data segment of the `SzAttributeSearchResponse`
@@ -4418,11 +4744,17 @@ components:
           * `WITH_DUPLICATES` - ** (default value) ** Group near-duplicate
                                 feature values and return a representative value
                                 along with its near duplicate values.
+          * `ATTRIBUTED` - Same as `WITH_DUPLICATES` but with record-level
+                           references attributing each feature to the record(s)
+                           that provided it for the entity along with any
+                           usage type that might have been associated with the
+                           feature at the record level.
       type: string
       enum:
         - NONE
         - REPRESENTATIVE
         - WITH_DUPLICATES
+        - ATTRIBUTED
       default: WITH_DUPLICATES
     SzRelationshipMode:
       description: >-
@@ -4435,12 +4767,16 @@ components:
              information for related entities with the `partial` property of the
              `SzRelatedEntity` instances set to `true`.  Obtaining additional
              information requires subsequent API calls.
-          * `FULL` - Include full data on the first-degree related entities.
-             This option obtains entity network at one degree for the requested
-             entity and will fully populate up to 1000 related entities and sets
-             the `partial` property of those `SzRelatedEntity` instances to
-             `false`.  Related entities beyond the first 1000 will be left
-             incomplete and have their `partial` property will be set to `true`.
+          * `FULL` - Include full data on the first-degree related entities
+             according to the `featureMode` and `detailLevel` **unless**
+             `forceMinimal` is `true`.  This option obtains the entity network
+             at one degree for the requested entity and will populate up to 1000
+             related entities as much as possible with respect to the
+             `featureMode` and `detailLevel`.  Related entities beyond the first
+             1000 will be left incomplete and have their `partial` property set
+             to `true` regardless of the `detailLevel` and `featureMode`.  If
+             this value is specified along with `forceMinimal=true` then
+             `PARTIAL` is used instead.
       type: string
       enum:
         - NONE
@@ -4474,6 +4810,44 @@ components:
         - SUFFICIENT
         - PREFERRED
         - OPTIONAL
+    SzDetailLevel:
+      description: >-
+        Describes the level of detail desired for entity data when obtained via
+        the various endpoints that return entity data.  Details for features of
+        entities as well as the related entities of entities are controlled by
+        other flags.  Possible values are:
+          * `MINIMAL` - The entities returned will include at most their
+                        entity ID's as well as identifiers for their
+                        constituent records (i.e.: data source code and record
+                        ID for each record).  This detail level is optimized for
+                        the fastest possible processing time.
+          * `BRIEF` - Builds upon `MINIMAL` to add the entity name and related
+                      entity match info when related entity match info when
+                      related entities are included.  This detail level aims to
+                      maintain as much speed as possible while providing names
+                      and relationship information for rendering a graph.
+          * `SUMMARY` - Identical to `BRIEF` except that individual record
+                        identifier information is excluded, leaving only the
+                        record summary (i.e.: a record count by data source
+                        code).  This reduces the size of the JSON document for
+                        large entities with thousands of records.  It may take
+                        longer to process than `BRIEF` but less data is
+                        returned as well, speeding up network transfer times.
+          * `VERBOSE` - Combines `BRIEF` and `SUMMARY` and then adds the
+                        original JSON data for each record, the record-level
+                        matching info, as well as formatted record data.  NOTE:
+                        the record-level matching info returned via "how" and
+                        "why" is often more useful than that embedded in the
+                        entity.  Further, the formatted record data, while
+                        readable, is not formatted according to locale (i.e.:
+                        address, name and date formatting may not appear as
+                        expected to a user).
+      type: string
+      enum:
+        - MINIMAL
+        - BRIEF
+        - SUMMARY
+        - VERBOSE
     SzAttributeType:
       description: >-
         Describes an attribute type that partially (or fully) describes a
@@ -4540,21 +4914,57 @@ components:
           format: int64
         - $ref: '#/components/schemas/SzRecordId'
         - type: string
+    SzRecordIdentifier:
+      description: >-
+        Identifies a record by its data source code and record ID.  This is
+        either a JSON-encoded `SzRecordId` or a delimited string where the first
+        character is the delimiter, followed by the data source code, then the
+        delimiter and the record ID (e.g.: `|CUSTOMERS|ABC123`).
+      oneOf:
+        - $ref: '#/components/schemas/SzRecordId'
+        - type: string
     SzEntityIdentifiers:
       description: >-
         Identifies zero or more entities by either its entity ID or by the
         data source code and record ID of one of their constituent records.
         Identifiers in the array are homogeneous, either all entity IDs or
-        all RecordId instances containing the data-source-code/record-id pair.
-        If specified as record IDs they are either JSON-encoded `SzRecordId`
-        instances or a delimited string where the first character is the
-        delimiter, followed by the data source code, then the delimiter and the
-        record ID (e.g.: `|CUSTOMERS|ABC123`).
+        all `SzRecordId` instances containing the data-source-code/record-id
+        pair.  If specified as record IDs they are either JSON-encoded
+        `SzRecordId` instances or a delimited string where the first character
+        is the delimiter, followed by the data source code, then the delimiter
+        and the record ID (e.g.: `|CUSTOMERS|ABC123`).
       oneOf:
         - type: array
           items:
             type: integer
             format: int64
+        - type: array
+          items:
+            $ref: '#/components/schemas/SzRecordId'
+        - type: array
+          items:
+            type: string
+        - type: array
+          items:
+            oneOf:
+              - $ref: '#/components/schemas/SzRecordId'
+              - type: string
+    SzRecordIdentifiers:
+      description: >-
+        Identifies zero or more records by their data source codes and record
+        ID's.  Identifiers in the array are homogeneous, either all entity IDs or
+        all RecordId instances containing the data-source-code/record-id pair.
+        The record ID's are either JSON-encoded `SzRecordId` instances or a
+        delimited string where the first character is the delimiter, followed
+        by the data source code, then the delimiter and the record ID (e.g.:
+        `|CUSTOMERS|ABC123`).
+      oneOf:
+        - type: array
+          items:
+            $ref: '#/components/schemas/SzRecordId'
+        - type: array
+          items:
+            type: string
         - type: array
           items:
             oneOf:
@@ -4741,6 +5151,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SzFlaggedEntity'
+    SzFeatureReference:
+      description: >-
+        Describes a record's reference to an entity feature along with the
+        optional usage type with which the record references the feature.
+      type: object
+      properties:
+        internalId:
+          description: >-
+            The internal feature ID identifying the feature so that it might
+            be identified and referenced.
+          type: integer
+          format: int64
+        usageType:
+          description: >-
+            The optional associated usage type (e.g.: "HOME or "WORK).  This is
+            the usage type with which the record loaded the feature (if any).
+            Other records in the same entity may have the same feature with a
+            different usage type.
+          type: string
+          nullable: true
     SzEntityRecord:
       description: >-
         Describes a record (aka: observed entity) that has been loaded for
@@ -4758,6 +5188,14 @@ components:
             The identifier that uniquely identifies this record from other
             records from the same data source.  This may have been loaded with
             the record or automatically generated from the record's data.
+        featureReferences:
+          description: >-
+            The optional array of record feature references to the entity
+            features along with the record's usage type if any.
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/SzFeatureReference'
         lastSeenTimestamp:
           description: >-
             The timestamp that the record was most recently loaded or updated.
@@ -4849,27 +5287,11 @@ components:
                 record to the first record in the resolved entity.  This is
                 blank for the first record.
               type: string
-            matchScore:
-              description: >-
-                The match score between the first record in the resolved
-                entity and this record.  The higher the score the closer
-                the match.  This is `null` for the first record in the
-                resolved entity.
-              type: integer
-              format: int32
-              nullable: true
             matchLevel:
               description: >-
                 The integer "match level" describing how the first record in
                 the resolved entity matched to this record.  This is zero for
                 the first record and usually one (1) for other records.
-              type: integer
-              format: int32
-            refScore:
-              description: >-
-                The ref score between the first record in the resolved entity
-                and this record.  This is zero (0) for the first record in the
-                resolved entity.
               type: integer
               format: int32
     SzDataSourceRecordSummary:
@@ -5108,8 +5530,9 @@ components:
             records, otherwise they are not provided.  Also, the
             recordSummary items may be missing the topRecordIds if partial
             is true.  This can be true for partially retrieved related
-            entities or if features are suppressed or if the minimal
-            response flag has been specified.
+            entities or if features are suppressed, if the detail level has
+            has suppressed records or if the force-minimal response flag has
+            been specified.
           type: boolean
         lastSeenTimestamp:
           description: >-
@@ -5132,14 +5555,6 @@ components:
                 matched to the primary resolved entity.
               type: integer
               format: int32
-            matchScore:
-              description: >-
-                The match score between the primary resolved entity and
-                this related entity.  The higher the score the closer
-                the match.
-              type: integer
-              format: int32
-              nullable: true
             matchKey:
               description: >-
                 The match key describing what features matched between
@@ -5150,12 +5565,6 @@ components:
                 The code identifying the resolution rule that related
                 this entity to the primary resolved entity.
               type: string
-            refScore:
-              description: >-
-                The ref score between the primary resolved entity and
-                this related entity.
-              type: integer
-              format: int32
     SzRelationshipType:
       description: >-
         Describes how an entity is related to another (either a possible match,
@@ -5223,6 +5632,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SzRelatedEntity'
+    SzVirtualEntityData:
+      description: >-
+        Describes the data associated with an `SzVirtualEntityResponse`
+        which currently includes only an `SzResolvedEntity`.
+      type: object
+      properties:
+        resolvedEntity:
+          description: The ResolvedEntity describing the primary entity.
+          $ref: '#/components/schemas/SzResolvedEntity'
     SzAttributeSearchResultType:
       description: >-
         Describes how the entity matching the search attributes would have
@@ -5477,8 +5895,7 @@ components:
         incompleteRecordCount:
           description: >-
             The number of records from the bulk data set within the aggregate
-            group that are missing either a `DATA_SOURCE` value or `ENTITY_TYPE`
-            value.
+            group that are missing either a `DATA_SOURCE` value.
           type: integer
           format: int32
         failedRecordCount:
@@ -5927,7 +6344,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SzRelatedFeatures'
-    SzMatchInfo:
+    SzWhyMatchInfo:
       description: >-
         The match info describing why two entities (or records) resolve or
         relate to one another.
@@ -6021,9 +6438,9 @@ components:
           $ref: '#/components/schemas/SzWhyPerspective'
         matchInfo:
           description: >-
-            The `SzMatchInfo` providing the details of the result.
+            The `SzWhyMatchInfo` providing the details of the result.
           nullable: false
-          $ref: '#/components/schemas/SzMatchInfo'
+          $ref: '#/components/schemas/SzWhyMatchInfo'
     SzWhyEntitiesResult:
       description: >-
         Describes why two entities did not resolve or why they related.
@@ -6043,9 +6460,9 @@ components:
           format: int64
         matchInfo:
           description: >-
-            The `SzMatchInfo` providing the details of the result.
+            The `SzWhyMatchInfo` providing the details of the result.
           nullable: false
-          $ref: '#/components/schemas/SzMatchInfo'
+          $ref: '#/components/schemas/SzWhyMatchInfo'
     SzWhyRecordsResult:
       description: >-
         Describes why two records might resolve.
@@ -6063,9 +6480,180 @@ components:
           $ref: '#/components/schemas/SzWhyPerspective'
         matchInfo:
           description: >-
-            The `SzMatchInfo` providing the details of the result.
+            The `SzWhyMatchInfo` providing the details of the result.
           nullable: false
-          $ref: '#/components/schemas/SzMatchInfo'
+          $ref: '#/components/schemas/SzWhyMatchInfo'
+    SzHowMatchInfo:
+      description: >-
+        The match info describing how a step in an entity's resolution completed
+        and why the two virtual entities were resolved.
+      type: object
+      properties:
+        matchKey:
+          description: >-
+            The match key indicating the components of the match.
+          nullable: false
+          type: string
+        resolutionRule:
+          description: >-
+            The resolution rule that triggered the match.
+          nullable: true
+          type: string
+        featureScores:
+          description: >-
+            The map of feature types to arrays of `SzFeatureScore` instances
+            for that feature type.
+          nullable: true
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/SzFeatureScore'
+    SzVirtualEntityRecord:
+      description: >-
+        Describes a record that belongs to a virtual entity.  This identifies
+        the record as well as its internal ID to understand which records in
+        the virtual entity are considered to be duplicates of each other.
+      type: object
+      properties:
+        dataSource:
+          description: >-
+            The data source code that uniquely identifies the data source
+            associated with the record.
+          type: string
+          nullable: false
+        recordId:
+          description: >-
+            The record ID that uniquely identifies a record within the
+            respective data source.
+          type: string
+          nullable: false
+        internalId:
+          description: >-
+            The unique internal ID for the record.  Those records having the
+            same value for this field are effectively identical for the purpose
+            of entity resolution and automatically bound together.
+          type: string
+          nullable: false
+    SzVirtualEntity:
+      description: >-
+        Describes a virtual entity that describes an interim resolution step
+        for an actual entity.  Virtual entities that consist of a single record
+        (or multiple "identical" records) are considered singletons and are the
+        initial building blocks in how an entity is resolved.  Those with
+        multiple distinct records are compound virtual entities formed from
+        resolving two virtual entities.
+      type: object
+      properties:
+        virtualEntityId:
+          description: >-
+            The unique identifier that distinguishes this virtual entity from
+            all other virtual entities among all steps in a "how" result.
+          type: string
+          nullable: false
+        singleton:
+          description: >-
+            Indicates if the virtual entity consists of a a single record or
+            one or more effectively identical records (i.e.: with the same
+            internal ID) with a value of `true`.  If this virtual entity
+            comprises multiple distinct records then this is `false`.
+          type: boolean
+          nullable: false
+        records:
+          description: >-
+            The array of `SzVirtualEntityRecords` identifying the constituent
+            records of the virtual entity.  Those records in the array with the
+            same `internalId` property are effectively identical for the
+            purposes of entity resolution.
+          type: array
+          items:
+            $ref: '#/components/schemas/SzVirtualEntityRecord'
+    SzResolutionStep:
+      description: >-
+        Describes a single step in describing how an entity was created.  Each
+        step consists of either the formation of a new "virtual entity" from
+        two records, the adding of a record to an existing virtual entity to
+        create a new virtual entity, or the resolving of two virtual entities
+        into a new virtual entity consisting of all the records.
+      type: object
+      properties:
+        stepNumber:
+          description: >-
+            The step number indicating the order of this step relative to other
+            steps if the steps were flattened to be linear.  However, the
+            non-linear nature of entity resolution means that the ordering of
+            the steps is only relevant within a single branch of the resolution
+            tree.
+          type:  integer
+          format: int32
+          nullable: false
+        inboundVirtualEntity:
+          description: >-
+            The `SzVirtualEntity` describing the inbound virtual entity.
+          nullable: false
+          $ref: '#/components/schemas/SzVirtualEntity'
+        candidateVirtualEntity:
+          description: >-
+            The `SzVirtualEntity` describing the candidate virtual entity.
+          nullable: false
+          $ref: '#/components/schemas/SzVirtualEntity'
+        matchInfo:
+          description: >-
+            The `SzHowMatchInfo` describing how the two virtual entities
+            matched each other.
+          nullable: false
+          $ref: '#/components/schemas/SzHowMatchInfo'
+        resolvedVirtualEntityId:
+          description: >-
+            The virtual entity ID identifying the virtual entity that resulted
+            from resolving the inbound and candidate virtual entities.
+          nullable: false
+          type: string
+    SzHowEntityResult:
+      description: >-
+        Describes the result of the "how entity" operation as a mapping of
+        non-singleton virtual entity ID's to their corresponding
+        `SzResolutionStep` instances as well as an array of `SzVirtualEntity`
+        instances describing the possible final states for the entity.
+        **NOTE**: If there are more than one possible final states then the
+        entity requires reevaluation, while a result with a single final state
+        does not require reevaluation.
+      type: object
+      properties:
+        finalStates:
+          description: >-
+            The array of `SzVirtualEntity` instances describing the possible
+            final states for the entity.  If there are more than one elements
+            in the array then the entity requires reevaluation.  If there is
+            only a single element in the array, then reevaluation is not
+            required.  This array will always have at least one element.
+          nullable: false
+          type: array
+          items:
+            $ref: '#/components/schemas/SzVirtualEntity'
+        resolutionSteps:
+          description: >-
+            The map of virtual entity ID's for non-singleton virtual entities
+            to `SzResolutionStep` instances describing how the virtual entity
+            for the respective virtual entity ID was formed.  Since singleton
+            virtual entities are base building blocks, they do not have an
+            associated how step.  They are simply formed by the loading of a
+            record to the repository.
+          nullable: false
+          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/SzResolutionStep'
+    SzHowEntityResponse:
+      description: >-
+        The response describing the result of the "how entity" operation.
+      allOf:
+        - $ref: '#/components/schemas/SzResponseWithRawData'
+        - type: object
+          properties:
+            data:
+              description: >-
+                The data field is the `SzHowEntityResult` itself.
+              $ref: '#/components/schemas/SzHowEntityResult'
     SzQueueInfo:
       description: >-
         Describes a configured queue.


### PR DESCRIPTION
- Updated to `senzing-api-server` version `3.3.0` including all changes provided
  by that:
  - Adds support for `SENZING_ENGINE_CONFIGURATION_JSON` environment variable
    per Issue #61 
  - Adds "how entity" support (both by record ID and entity ID)
  - Adds "get virtual entity" support
  - Adds `detailLevel` support
  - Adds `SzFeatureMode.ATTRIBUTED` support
  - See `CHANGELOG.md` from `Senzing/senzing-api-server` for further details
- Updated dependencies to match the `senzing-api-server` dependency versions
