### PR TITLE
V3.2.1 Release: Updated to senzing-api-server version 3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - 2022-08-23
+
+### Changed in 3.2.1
+
+- Updated dependency on `Senzing/senzing-api-server` to a minimum version of
+  `3.3.1` to resolve issue with environment variable fallbacks for primary  
+  options which typically lack dependencies.
+
 ## [3.2.0] - 2022-08-18
 
 ### Changed in 3.2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2022-08-12
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.1.1"
+      Version="3.2.1"
 
 # Set environment variables.
 
@@ -49,7 +49,7 @@ ENV REFRESHED_AT=2022-08-12
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.1.1"
+      Version="3.2.1"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.2.0</version>
+  <version>3.2.1</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[3.3.0, 3.999.999]</version>
+      <version>[3.3.1, 3.999.999]</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>


### PR DESCRIPTION
Updated dependency on `Senzing/senzing-api-server` to a minimum version of `3.3.1` to resolve issue with environment variable fallbacks for primary options which typically lack dependencies.