### PR TITLE
Version 3.3.7: Handle JSON-Lines content with application/json Content-Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.5] - 2023-01-23
+
+### Changed in 3.3.5
+
+- Updated `senzing-api-server` dependency to version `3.4.10`
+- Modified bulk-data API to allow JSON-lines (`application/x-jsonlines`)
+  content when JSON (`application/json`) Content-Type header is provided.
+
 ## [3.3.4] - 2023-01-05
 
 ### Changed in 3.3.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2022-10-27
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.3.4"
+      Version="3.3.5"
 
 # Set environment variables.
 
@@ -49,7 +49,7 @@ ENV REFRESHED_AT=2022-10-27
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.3.4"
+      Version="3.3.5"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.3.4</version>
+  <version>3.3.5</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[3.4.7, 3.999.999]</version>
+      <version>[3.4.10, 3.999.999]</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>

--- a/src/main/java/com/senzing/poc/services/BulkDataStreamServices.java
+++ b/src/main/java/com/senzing/poc/services/BulkDataStreamServices.java
@@ -86,7 +86,7 @@ public class BulkDataStreamServices implements BulkDataStreamSupport {
                                         null,
                                         null);
 
-    } catch (ForbiddenException e) {
+    } catch (ClientErrorException e) {
       throw e;
 
     } catch (RuntimeException e) {
@@ -165,7 +165,7 @@ public class BulkDataStreamServices implements BulkDataStreamSupport {
                                         null,
                                         null);
 
-    } catch (ForbiddenException e) {
+    } catch (ClientErrorException e) {
       throw e;
 
     } catch (RuntimeException e) {
@@ -249,7 +249,7 @@ public class BulkDataStreamServices implements BulkDataStreamSupport {
                                  sse,
                                  null);
 
-    } catch (ForbiddenException e) {
+    } catch (ClientErrorException e) {
       throw e;
 
     } catch (RuntimeException e) {
@@ -335,7 +335,7 @@ public class BulkDataStreamServices implements BulkDataStreamSupport {
                                  sse,
                                  null);
 
-    } catch (ForbiddenException e) {
+    } catch (ClientErrorException e) {
       throw e;
 
     } catch (RuntimeException e) {

--- a/src/main/java/com/senzing/poc/services/BulkDataStreamSupport.java
+++ b/src/main/java/com/senzing/poc/services/BulkDataStreamSupport.java
@@ -96,6 +96,8 @@ public interface BulkDataStreamSupport
       Sse                         sse,
       Session                     webSocketSession)
   {
+    MediaType specifiedMediaType = mediaType;
+
     // check if the maximum batch count is less-than or equal to zero
     if (maxBatchCount <= 0) maxBatchCount = Integer.MAX_VALUE;
 
@@ -140,10 +142,18 @@ public interface BulkDataStreamSupport
            BufferedReader     br  = new BufferedReader(isr))
       {
         // if format is null then RecordReader will auto-detect
-        RecordReader recordReader = new RecordReader(bulkDataSet.getFormat(),
+        RecordReader recordReader = new RecordReader(null,
                                                      br,
                                                      dataSourceMap,
                                                      loadId);
+
+        this.verifyBulkDataFormat(specifiedMediaType,
+                                  bulkDataSet.getFormat(),
+                                  recordReader.getFormat(),
+                                  uriInfo,
+                                  timers);
+
+        // override the format accordingly
         bulkDataSet.setFormat(recordReader.getFormat());
 
         if (LoggingUtilities.isDebugLogging()) {


### PR DESCRIPTION
- Updated `senzing-api-server` dependency to version `3.4.10`
- Modified bulk-data API to allow JSON-lines (`application/x-jsonlines`) content when JSON (`application/json`) Content-Type header is provided.
