### PR TITLE
Version 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated `senzing-api-server` dependency to version `3.5.0`
 - Updated third-party dependency versions to newer versions
+- Updated underlying Docker images.
+
 
 ## [3.3.9] - 2023-03-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2023-04-03
+
+### Changed in 3.4.0
+
+- Updated `senzing-api-server` dependency to version `3.5.0`
+- Updated third-party dependency versions to newer versions
+
 ## [3.3.9] - 2023-03-10
 
 ### Changed in 3.3.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-04-03
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.3.9"
+      Version="3.4.0"
 
 # Set environment variables.
 
@@ -49,7 +49,7 @@ ENV REFRESHED_AT=2023-04-03
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.3.9"
+      Version="3.4.0"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,19 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.3.9</version>
+  <version>3.4.0</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[3.4.12, 3.999.999]</version>
+      <version>[3.5.0, 3.999.999]</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.41.0.0</version>
+       <version>3.41.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>71.1</version>
+      <version>72.1</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>


### PR DESCRIPTION
- Updated `senzing-api-server` dependency to version `3.5.0`

- Updated third-party dependency versions to newer versions

- Updated underlying Docker images.
