### PR TITLE
Caceres.version 3.4.5 - Updated dependencies to newer versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `pom.xml` to POC Server version `3.4.5`
 - Updated `Dockerfile` to version `3.4.5`
 - Updated `sqlite-jdbc` to version `3.42.0.0`
+- Updated `senzing-api-server` to version `3.5.5`
 - Updated Jersey dependencies to version `2.40`
 - Updated `icu4j` to version `73.2`
 - Updated `sqs` to version `2.20.94`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.3] - 2023-06-30
+
+### Changed in 3.4.3
+
+- Updated `sqlite-jdbc` to version `3.42.0.0`
+- Updated Jersey dependencies to version `2.40`
+- Updated `icu4j` to version `73.2`
+- Updated `sqs` to version `2.20.94`
+- Updated `amqp-client` to version `5.18.0`
+- Updated `kafka-clients` to version `3.5.0`
+
+## [3.4.1] - 2023-05-10
+
 ## [3.4.2] - 2023-06-08
 
 ### Changed in 3.4.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-05-09
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.4.2"
+      Version="3.4.3"
 
 # Set environment variables.
 
@@ -49,7 +49,7 @@ ENV REFRESHED_AT=2023-05-09
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.4.2"
+      Version="3.4.3"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,19 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.4.2</version>
+  <version>3.4.3</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[3.5.2, 3.999.999]</version>
+      <version>[3.5.5, 3.999.999]</version>
     </dependency>
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.41.2.1</version>
+       <version>3.42.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -72,27 +72,27 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.37</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -103,17 +103,17 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.39</version>
+      <version>2.40</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>73.1</version>
+      <version>73.2</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>
@@ -169,17 +169,17 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.20.20</version>
+      <version>2.20.94</version>
     </dependency>
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.17.0</version>
+      <version>5.18.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.3.1</version>
+      <version>3.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION
Version 3.4.5 Release
- Updated `pom.xml` to POC Server version `3.4.5`
- Updated `Dockerfile` to version `3.4.5`
- Updated `sqlite-jdbc` to version `3.42.0.0`
- Updated `senzing-api-server` to version `3.5.5`
- Updated Jersey dependencies to version `2.40`
- Updated `icu4j` to version `73.2`
- Updated `sqs` to version `2.20.94`
- Updated `amqp-client` to version `5.18.0`
- Updated `kafka-clients` to version `3.5.0`
