### PR TITLE
Version 3.5.0 of POC Server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "senzing-api-server"]
 	path = senzing-api-server
 	url = https://github.com/Senzing/senzing-api-server.git
+[submodule "data-mart-replicator"]
+	path = data-mart-replicator
+	url = git@github.com:Senzing/data-mart-replicator.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/Senzing/senzing-api-server.git
 [submodule "data-mart-replicator"]
 	path = data-mart-replicator
-	url = git@github.com:Senzing/data-mart-replicator.git
+	url = https://github.com/Senzing/data-mart-replicator.git

--- a/.project
+++ b/.project
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
 	<name>senzing-poc-server</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1699048350458</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.0] - 2023-12-12
+
+### Changed in 3.5.0
+
+- Added integration with embedded Data Mart Replicator
+  - Added `data-mart-replicator` submodule
+  - Added options to configure data mart database connection 
+  - Added initial REST operations for data mart statistics
+- Deprecated stream loader integration
+  - Marked all command-line options deprecated
+  - Stream loader integration to be removed in version 4.0
+  - Removed startup requirement for load queue configuration
+
 ## [3.4.7] - 2023-09-29
 
 ### Changed in 3.4.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-09-29
 
 LABEL Name="senzing/senzing-poc-server-builder" \
       Maintainer="support@senzing.com" \
-      Version="3.4.7"
+      Version="3.5.0"
 
 # Set environment variables.
 
@@ -24,6 +24,12 @@ ENV LD_LIBRARY_PATH=${SENZING_ROOT}/g2/lib:${SENZING_ROOT}/g2/lib/debian
 
 COPY senzing-api-server /senzing-api-server
 WORKDIR /senzing-api-server
+RUN make install
+
+# Build "data-mart-replicator.jar".
+
+COPY data-mart-replicator /data-mart-replicator
+WORKDIR /data-mart-replicator
 RUN make install
 
 # Build "senzing-poc-server.jar".
@@ -45,7 +51,7 @@ ENV REFRESHED_AT=2023-09-29
 
 LABEL Name="senzing/senzing-poc-server" \
       Maintainer="support@senzing.com" \
-      Version="3.4.7"
+      Version="3.5.0"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ docker-package: docker-build
 docker-build:
 	docker build \
 		--no-cache \
+		--progress=plain \
 		--tag $(DOCKER_IMAGE_NAME) \
 		--tag $(DOCKER_IMAGE_NAME):$(GIT_VERSION) \
 		.

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ to obtain a help message describing all available options.
 For example:
 
 ```console
-$ java -jar senzing-poc-server-1.0.2.jar <options>
 
-<options> includes:
+java -jar senzing-poc-server-3.5.0.jar <options>
+
+<options> includes: 
+
 
 [ Standard Options ]
    --help
@@ -126,17 +128,19 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
 
    --enable-admin [true|false]
         Also -enableAdmin.  Enables administrative functions via the API
-        server.  The true/false parameter is optional, if not specified then
-        true is assumed.  If specified as false then it is the same as omitting
-        the option with the exception that omission falls back to the
-        environment variable setting whereas an explicit false overrides any
-        environment variable.  If not specified then administrative functions
-        will return a 403 Forbidden response.
+        server.  Administrative functions include those that would modify
+        the active configuration (e.g.: adding data sources, entity types,
+        or entity classes).  The true/false parameter is optional, if not
+        specified then true is assumed.  If specified as false then it is
+        the same as omitting the option with the exception that omission
+        falls back to the environment variable setting whereas an explicit
+        false overrides any environment variable.  If not specified then
+        administrative functions will return a 403 Forbidden response.
         --> VIA ENVIRONMENT: SENZING_API_SERVER_ENABLE_ADMIN
 
    --http-port <port-number>
         Also -httpPort.  Sets the port for HTTP communication.  If not
-        specified, then the default port (2080) is used.
+        specified, then the default port (8250) is used.
         Specify 0 for a randomly selected available port number.  This
         option cannot be specified if SSL client authentication is configured.
         --> VIA ENVIRONMENT: SENZING_API_SERVER_PORT
@@ -157,7 +161,7 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
         --> VIA ENVIRONMENT: SENZING_API_SERVER_ALLOWED_ORIGINS
 
    --concurrency <thread-count>
-        Also -concurrency.  Sets the number of threads available for executing
+        Also -concurrency.  Sets the number of threads available for executing 
         Senzing API functions (i.e.: the number of engine threads).
         If not specified, then this defaults to 8.
         --> VIA ENVIRONMENT: SENZING_API_SERVER_CONCURRENCY
@@ -200,6 +204,7 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
         then it may be visible to other users via process monitoring.
         EXAMPLE: -initJson "{"PIPELINE":{ ... }}"
         --> VIA ENVIRONMENT: SENZING_API_SERVER_INIT_JSON
+                             SENZING_ENGINE_CONFIGURATION_JSON (fallback)
 
    --config-id <config-id>
         Also -configId.  Use with the -iniFile, -initFile, -initEnvVar or
@@ -283,8 +288,44 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
         determine when to shutdown.
         --> VIA ENVIRONMENT: SENZING_API_SERVER_MONITOR_FILE
 
+
+[ Data Mart Database Connectivity Options ]
+   The following options pertain to configuring the connection to the data-mart
+   database.  Exactly one such database must be configured.
+
+   --sqlite-database-file <url>
+        Specifies an SQLite database file to open (or create) to use as the
+        data-mart database.  NOTE: SQLite may be used for testing, but because
+        only one connection may be made, it will not scale for production use.
+        --> VIA ENVIRONMENT: SENZING_DATA_MART_SQLITE_DATABASE_FILE
+
+   --postgresql-host <hostname>
+        Used to specify the hostname for connecting to PostgreSQL as the 
+        data-mart database.
+        --> VIA ENVIRONMENT: SENZING_DATA_MART_POSTGRESQL_HOST
+
+   --postgresql-port <port>
+        Used to specify the port number for connecting to PostgreSQL as the 
+        data-mart database.
+        --> VIA ENVIRONMENT: SENZING_DATA_MART_POSTGRESQL_PORT
+
+   --postgresql-database <database>
+        Used to specify the database name for connecting to PostgreSQL as the 
+        data-mart database.
+        --> VIA ENVIRONMENT: SENZING_DATA_MART_POSTGRESQL_DATABASE
+
+   --postgresql-user <user name>
+        Used to specify the user name for connecting to PostgreSQL as the 
+        data-mart database.
+        --> VIA ENVIRONMENT: SENZING_DATA_MART_POSTGRESQL_USER
+
+   --postgresql-password <password>
+        Used to specify the password for connecting to PostgreSQL as the 
+        data-mart database.
+        --> VIA ENVIRONMENT: SENZING_DATA_MART_POSTGRESQL_PASSWORD
+
 [ HTTPS / SSL Options ]
-   The following options pertain to HTTPS / SSL configuration.  The
+   The following options pertain to HTTPS / SSL configuration.  The 
    --key-store and --key-store-password options are the minimum required
    options to enable HTTPS / SSL communication.  If HTTPS / SSL communication
    is enabled, then HTTP communication is disabled UNLESS the --http-port
@@ -294,7 +335,7 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
 
    --https-port <port-number>
         Also -httpsPort.  Sets the port for secure HTTPS communication.
-        While the default HTTPS port is 2443 if not specified,
+        While the default HTTPS port is 8263 if not specified,
         HTTPS is only enabled if the --key-store option is specified.
         Specify 0 for a randomly selected available port number.
         --> VIA ENVIRONMENT: SENZING_API_SERVER_SECURE_PORT
@@ -326,6 +367,7 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
         Also -clientKeyStorePassword.  Specifies the password for decrypting
         the key store file specified with the --client-key-store option.
         --> VIA ENVIRONMENT: SENZING_API_SERVER_CLIENT_KEY_STORE_PASSWORD
+
 
 [ Asynchronous Info Queue Options ]
    The following options pertain to configuring an asynchronous message
@@ -398,76 +440,94 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
         Kafka as part of specifying a Kafka info topic.
         --> VIA ENVIRONMENT: SENZING_KAFKA_INFO_TOPIC
 
-[ Asynchronous Load Queue Options ]
+
+[ *** DEPRECATED *** Asynchronous Load Queue Options ]
    The following options pertain to configuring an asynchronous message
    queue on which to send record messages to be loaded by the stream loader.
    At most one such queue can be configured.  If a "load" queue is
    configured then endpoints that leverage the load queue become available.
+   *** NOTE ***: These options are DEPRECATED since the Senzing stream
+   loader is being deprecated.  Loading records via the stream loader will
+   only update the data mart if the stream loader is publishing INFO messages
+   to a queue that are being consumed by a separate Data Mart Replicator
+   configured for the same data mart database
 
    --sqs-load-url <url>
+        *** DEPRECATED: See deprecation note above ***
         Also -sqsLoadUrl.  Specifies an Amazon SQS queue URL as the load queue.
         --> VIA ENVIRONMENT: SENZING_SQS_LOAD_QUEUE_URL
                              SENZING_SQS_QUEUE_URL (fallback)
 
    --rabbit-load-host <hostname>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadHost.  Used to specify the hostname for connecting to
         RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_HOST
                              SENZING_RABBITMQ_HOST (fallback)
 
    --rabbit-load-port <port>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadPort.  Used to specify the port number for connecting
         to RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_PORT
                              SENZING_RABBITMQ_PORT (fallback)
 
    --rabbit-load-user <user name>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadUser.  Used to specify the user name for connecting to
         RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_USERNAME
                              SENZING_RABBITMQ_USERNAME (fallback)
 
    --rabbit-load-password <password>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadPassword.  Used to specify the password for connecting
         to RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_PASSWORD
                              SENZING_RABBITMQ_PASSWORD (fallback)
 
    --rabbit-load-virtual-host <virtual host>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadVirtualHost.  Used to specify the virtual host for
         connecting to RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_VIRTUAL_HOST
                              SENZING_RABBITMQ_VIRTUAL_HOST (fallback)
 
    --rabbit-load-exchange <exchange>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadExchange.  Used to specify the exchange for connecting
         to RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_EXCHANGE
                              SENZING_RABBITMQ_EXCHANGE (fallback)
 
    --rabbit-load-routing-key <routing key>
+        *** DEPRECATED: See deprecation note above ***
         Also -rabbitLoadRoutingKey.  Used to specify the routing key for
         connecting to RabbitMQ as part of specifying a RabbitMQ load queue.
         --> VIA ENVIRONMENT: SENZING_RABBITMQ_LOAD_ROUTING_KEY
                              SENZING_RABBITMQ_ROUTING_KEY (fallback)
 
    --kafka-load-bootstrap-server <bootstrap servers>
+        *** DEPRECATED: See deprecation note above ***
         Also -kafkaLoadBootstrapServer.  Used to specify the bootstrap servers
         for connecting to Kafka as part of specifying a Kafka load topic.
         --> VIA ENVIRONMENT: SENZING_KAFKA_LOAD_BOOTSTRAP_SERVER
                              SENZING_KAFKA_BOOTSTRAP_SERVER (fallback)
 
    --kafka-load-group <group id>
+        *** DEPRECATED: See deprecation note above ***
         Also -kafkaLoadGroupId.  Used to specify the group ID for connecting to
         Kafka as part of specifying a Kafka load topic.
         --> VIA ENVIRONMENT: SENZING_KAFKA_LOAD_GROUP
                              SENZING_KAFKA_GROUP (fallback)
 
    --kafka-load-topic <topic>
+        *** DEPRECATED: See deprecation note above ***
         Also -kafkaLoadTopic.  Used to specify the topic name for connecting to
         Kafka as part of specifying a Kafka load topic.
         --> VIA ENVIRONMENT: SENZING_KAFKA_LOAD_TOPIC
                              SENZING_KAFKA_TOPIC (fallback)
+
 
 [ Advanced Options ]
    --config-mgr [config manager options]...
@@ -476,6 +536,7 @@ $ java -jar senzing-poc-server-1.0.2.jar <options>
         If this option is specified by itself then a help message on
         configuration manager options will be displayed.
         NOTE: If this option is provided, the server will not start.
+
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ native API.  This is done through one of: `--init-file`, `--init-env-var` or the
 Other command-line options may be useful to you as well.  Execute
 
 ```console
-java -jar target/senzing-poc-server-1.0.2.jar --help
+java -jar target/senzing-poc-server-3.5.0.jar --help
 ```
 
 to obtain a help message describing all available options.

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,23 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-api-server</artifactId>
-      <version>[3.5.6, 3.999.999]</version>
+      <version>[3.5.9, 3.999.999]</version>
     </dependency>
+    <dependency>
+      <groupId>com.senzing</groupId>
+      <artifactId>senzing-commons</artifactId>
+      <version>[3.1.4, 3.999.999]</version>
+    </dependency>
+    <dependency>
+      <groupId>com.senzing</groupId>
+      <artifactId>senzing-listener</artifactId>
+      <version>0.5.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.senzing</groupId>
+      <artifactId>data-mart-replicator</artifactId>
+      <version>1.0.0</version>
+    </dependency>    
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
@@ -251,49 +266,6 @@
   <build>
     <directory>${buildDirectory}</directory>
     <plugins>
-      <!-- plugin>
-        <groupId>io.swagger.codegen.v3</groupId>
-        <artifactId>swagger-codegen-maven-plugin</artifactId>
-        <version>3.0.19</version>
-        <executions>
-          <execution>
-            <phase>generate-test-sources</phase>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-            <configuration>
-              <inputSpec>${project.basedir}/senzing-rest-api-specification/senzing-rest-api.yaml</inputSpec>
-              <language>java</language>
-              <configOptions>
-                <dateLibrary>joda</dateLibrary>
-                <library>resttemplate</library>
-                <sourceFolder>src/gen/java/test</sourceFolder>
-              </configOptions>
-              <output>${project.build.directory}/generated-test-sources/swagger</output>
-              <modelPackage>com.senzing.gen.api.model</modelPackage>
-              <apiPackage>com.senzing.gen.api.services</apiPackage>
-              <invokerPackage>com.senzing.gen.api.invoker</invokerPackage>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin -->
-      <!-- plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>generate-test-sources</phase>
-              <goals>
-                <goal>add-test-source</goal>
-              </goals>
-              <configuration>
-                <sources>
-                  <source>${project.build.directory}/generated-test-sources/swagger/src/gen/java/test</source>
-                </sources>
-              </configuration>
-          </execution>
-        </executions>
-      </plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
@@ -301,39 +273,37 @@
         <executions>
           <execution>
             <phase>process-test-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
             <configuration>
-
               <target>
-                <property name="maven.classpath" refid="maven.compile.classpath"></property>
+                <property name="maven.classpath" refid="maven.compile.classpath"/>
                 <property environment="env"/>
                 <condition property="senzing.install.dir"
-                           value="${env.SENZING_DIR}"
-                           else="">
+                          value="${env.SENZING_DIR}"
+                          else="">
                   <isset property="env.SENZING_DIR"/>
                 </condition>
-                <mkdir dir="${project.build.directory}/test-classes/"></mkdir>
+                <mkdir dir="${project.build.directory}/test-classes/"/>
                 <javac includeantruntime="false"
-                       srcdir="senzing-api-server/src/test/java"
-                       destdir="${project.build.directory}/test-classes/"
-                       includes="com/senzing/api/GenerateTestJVMScript.java"
-                       classpath="${maven.classpath}" />
+                      srcdir="senzing-api-server/src/test/java"
+                      destdir="${project.build.directory}/test-classes/"
+                      includes="com/senzing/api/GenerateTestJVMScript.java"
+                      classpath="${maven.classpath}" />
 
                 <java classname="com.senzing.api.GenerateTestJVMScript">
                   <classpath>
-                    <pathelement path="${maven.classpath}"></pathelement>
+                    <pathelement path="${maven.classpath}"/>
                     <pathelement location="${project.build.directory}/test-classes/"/>
                     <pathelement location="${project.build.directory}/classes/"/>
                   </classpath>
                   <sysproperty key="senzing.install.dir"
-                               value="${senzing.install.dir}"/>
+                              value="${senzing.install.dir}"/>
                   <arg value="${project.build.directory}/java-wrapper/bin/java-wrapper.bat"/>
                 </java>
               </target>
-
             </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
           </execution>
         </executions>
       </plugin>
@@ -400,7 +370,7 @@
                 <exclude>META-INF/*.RSA</exclude>
               </excludes>
             </filter>
-           <filter>
+          <filter>
               <artifact>com.senzing:senzing-api-server*</artifact>
               <excludes>
                 <exclude>com/ibm/icu/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-poc-server</artifactId>
   <packaging>jar</packaging>
-  <version>3.4.7</version>
+  <version>3.5.0</version>
   <name>senzing-poc-server</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -31,7 +31,7 @@
     <dependency>
      <groupId>org.xerial</groupId>
      <artifactId>sqlite-jdbc</artifactId>
-       <version>3.43.0.0</version>
+       <version>3.42.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,78 +36,78 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-servlets -->
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlets</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-rewrite</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-proxy</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-server</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-common</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-servlet</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-server-impl</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-api</artifactId>
-      <version>9.4.52.v20230823</version>
+      <version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-sse</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet-core</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-jetty-http</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty</groupId>
@@ -118,42 +118,42 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.inject</groupId>
       <artifactId>jersey-hk2</artifactId>
-      <version>2.40</version>
+      <version>2.41</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <version>2.15.2</version>
+      <version>2.15.3</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.9.2</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>com.ibm.icu</groupId>
       <artifactId>icu4j</artifactId>
-      <version>73.2</version>
+      <version>74.1</version>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -2851,58 +2851,6 @@ paths:
                 $ref: '#/components/schemas/SzCountStatsResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/counts/entities:
-    get:
-      tags:
-        - Statistics
-      summary: >-
-        Gets the entity counts in total and by data source from the data mart.
-      description: >-
-        Gets the entity counts in total and by data source from the data mart.
-        *NOTE*: Data mart statistics may be slightly delayed from the entity
-        repository.
-      operationId: getEntityCountStatistics
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json; charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/SzCountStatsResponse'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SzCountStatsResponse'
-            default:
-              schema:
-                $ref: '#/components/schemas/SzCountStatsResponse'
-        '500':
-          $ref: '#/components/responses/ServerError'
-  /statistics/counts/records:
-    get:
-      tags:
-        - Statistics
-      summary: >-
-        Gets the record counts in total and by data source from the data mart.
-      description: >-
-        Gets the record counts in total and by data source from the data mart.
-        *NOTE*: Data mart statistics may be slightly delayed from the entity
-        repository.
-      operationId: getRecordCountStatistics
-      responses:
-        '200':
-          description: Successful response
-          content:
-            application/json; charset=UTF-8:
-              schema:
-                $ref: '#/components/schemas/SzCountStatsResponse'
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SzCountStatsResponse'
-            default:
-              schema:
-                $ref: '#/components/schemas/SzCountStatsResponse'
-        '500':
-          $ref: '#/components/responses/ServerError'
   /statistics/counts/data-sources/{dataSourceCode}:
     get:
       tags:
@@ -2932,60 +2880,98 @@ paths:
                 $ref: '#/components/schemas/SzSourceCountStatsResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/counts/data-sources/{dataSourceCode}/entities:
+  /statistics/entity-sizes/counts:
     get:
       tags:
         - Statistics
       summary: >-
-        Gets the entity counts for a specific data source from the data mart.
+        Gets the entity counts by entity size (Entity Size Breakdown).
       description: >-
-        Gets the entity counts for a specific data source from the data mart.
-        *NOTE*: Data mart statistics may be slightly delayed from the entity
-        repository.
-      operationId: getSourceEntityCountStatistics
-      parameters:
-        - $ref: '#/components/parameters/dataSourceCodePathParam'
+        Gets the number of entities in the repository for each entity size 
+        that exists.  *NOTE*: Data mart statistics may be slightly delayed
+        from the entity repository.
+      operationId: getEntitySizeBreakdown
       responses:
         '200':
           description: Successful response
           content:
             application/json; charset=UTF-8:
               schema:
-                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+                $ref: '#/components/schemas/SzEntitySizeBreakdownResponse'
             application/json:
               schema:
-                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+                $ref: '#/components/schemas/SzEntitySizeBreakdownResponse'
             default:
               schema:
-                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+                $ref: '#/components/schemas/SzEntitySizeBreakdownResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/counts/data-sources/{dataSourceCode}/records:
+  /statistics/entity-sizes/{entitySize}/count:
     get:
       tags:
         - Statistics
       summary: >-
-        Gets the records counts for a specific data source from the data mart.
+        Gets the count of entities having the specific number of records.
       description: >-
-        Gets the record counts for a specific data source from the data mart.
+        Gets the count of entities having the specific number of records.
+        If there are NO entities having the specified number of records then
+        this will return a 200 OK response with the result indicating a count
+        of zero entities rather than giving a 404 Not Found response.
         *NOTE*: Data mart statistics may be slightly delayed from the entity
         repository.
-      operationId: getSourceRecordCountStatistics
+      operationId: getEntitySizeCount
       parameters:
-        - $ref: '#/components/parameters/dataSourceCodePathParam'
+        - $ref: '#/components/parameters/entitySizePathParam'
       responses:
         '200':
           description: Successful response
           content:
             application/json; charset=UTF-8:
               schema:
-                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+                $ref: '#/components/schemas/SzEntitySizeCountResponse'
             application/json:
               schema:
-                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+                $ref: '#/components/schemas/SzEntitySizeCountResponse'
             default:
               schema:
-                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+                $ref: '#/components/schemas/SzEntitySizeCountResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /statistics/entity-sizes/{entitySize}/entities:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the entity ID's of the entities having the specific number of records.
+      description: >-
+        Gets the entity ID's of the entities having the number of records for the
+        specified entity size.  If no entities have the specified number of records
+        then this will return a 200 OK response that will have an empty array of
+        entity ID's rather than giving a 404 Not Found response.  Further, if there
+        are no entity ID's having the specified number of records that are greater
+        than the specified minimum entity ID then similarly a 200 OK response is 
+        returned but the array of ID's contained in the response will be empty.
+        *NOTE*: Data mart statistics may be slightly delayed from the entity
+        repository.        
+      operationId: getSourceRecordCountStatistics
+      parameters:
+        - $ref: '#/components/parameters/entitySizePathParam'
+        - $ref: '#/components/parameters/entityIdBoundQueryParam'
+        - $ref: '#/components/parameters/boundTypeQueryParam'
+        - $ref: '#/components/parameters/pageSizeQueryParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzPagedEntitiesResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzPagedEntitiesResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzPagedEntitiesResponse'
         '500':
           $ref: '#/components/responses/ServerError'
   /load-queue:
@@ -4271,6 +4257,72 @@ components:
       schema:
         type: boolean
         default: false
+    entityIdBoundQueryParam:
+      in: query
+      name: bound
+      required: false
+      description: >-
+        The optional parameter to provide for "paging" through entity ID's
+        associated with a statistic.  The value is specified as bound on the
+        entity ID values returned.  The type of bound is given by the 
+        `boundType` parameter.  For example, by default the `boundType` is
+        `EXCLUSIVE_LOWER` so the returned entity ID values must satisfy the
+        condition that they are strictly greater than the entity ID bound value.
+        To move to the "next page" of entity ID's specify the greatest entity ID
+        value from the current page and use `boundType` of `EXCLUSIVE_LOWER`.
+        To move to the "previous page" of entity ID's specify the least entity ID
+        value on the current page and use `boundType` of `EXCLUSIVE_UPPER`.  To
+        change the number of results shown on the current page specify the least
+        entity ID value on the current page and specify a `boundType` of 
+        `INCLUSIVE_LOWER` with a new `pageSize` value.
+      schema:
+        type: integer
+        format: int64
+        default: 0
+    boundTypeQueryParam:
+      in: query
+      name: boundType
+      required: false
+      description: >-
+        The optional parameter to provide for "paging" through entity ID's
+        associated with a statistic.  The value is specified as an `SzBoundType`
+        and the entity ID bound value is given by the `bound` parameter.  For
+        example, by default the `boundType` is `EXCLUSIVE_LOWER` so the returned
+        entity ID values must satisfy the condition that they are strictly greater
+        than the entity ID bound value.  To move to the "next page" of entity ID's
+        specify the greatest entity ID value from the current page and use
+        `boundType` of `EXCLUSIVE_LOWER`.  To move to the "previous page" of 
+        entity ID's specify the least entity ID value on the current page and use
+        a `boundType` of `EXCLUSIVE_UPPER`.  To change the number of results shown
+        on the current page specify the least entity ID value on the current page
+        and specify a `boundType` of `INCLUSIVE_LOWER` with a new `pageSize` value.
+        Possible values are:
+          * `INCLUSIVE_LOWER` - The bound represents an inclusive lower bound whereby
+                                values satisifying the bound will be greater-than or equal
+                                to the value associated with the bound.
+          * `EXCLUSIVE_LOWER` - The bound represents an exclusive lower bound whereby 
+                                values satisfying the bound will be strictly greater-than 
+                                the value associated with the bound.
+          * `INCLUSIVE_UPPER` - The bound represents an inclusive upper bound whereby
+                                values satisifying the bound will be less-than or equal
+                                to the value associated with the bound.
+          * `EXCLUSIVE_UPPER` - The bound represents an exclusive upper bound whereby 
+                                values satisfying the bound will be strictly less-than 
+                                the value associated with the bound.
+      schema:
+        default: EXCLUSIVE_LOWER
+        $ref: '#/components/schemas/SzBoundType'
+    pageSizeQueryParam:
+      in: query
+      name: pageSize
+      required: false
+      description: >-
+        The optional parameter to limit the number of returned results per page.
+      schema:
+        type: integer
+        format: int32
+        default: 100
+        minimum: 1
     dataSourceCodePathParam:
       in: path
       name: dataSourceCode
@@ -4327,6 +4379,24 @@ components:
         type: integer
         format: int32
         default: 3
+    entitySizePathParam:
+      in: path
+      name: entitySize
+      required: true
+      description: >-
+        The number of records for the entities of interest.
+      schema:
+        type: integer
+        format: int32
+    relationCountPathParam:
+      in: path
+      name: relationCount
+      required: true
+      description: >-
+        The number of relationships for the entities of interest.
+      schema:
+        type: integer
+        format: int32
   responses:
     ServerError:
       description: Unexpected server error occurred.
@@ -4823,6 +4893,66 @@ components:
                   type: array
                   items:
                     $ref: '#/components/schemas/SzEntityData'
+    SzPagedEntitiesResponse:
+      description: >-
+        Extends the BaseResponse to add the fields describing a list of
+        entity ID's that is "paged" with a boundary, a page size and a 
+        total entity count.
+      allOf:
+        - $ref: '#/components/schemas/SzBaseResponse'
+        - type: object
+          properties:
+            data:
+              description: >-
+                The data field is the `SzEntitiesPage` containing the entity ID's
+                and paging statistics.
+              $ref: '#/components/schemas/SzEntitiesPage'
+    SzEntitiesPage:
+      description: >-
+        Encapsulates a paged list of entity ID's identifying the entities
+        pertaining to a specific statistic.
+      type: object
+      required:
+        - bound
+        - boundType
+        - pageSize
+        - totalEntityCount
+        - entityCount
+        - entityIds
+      properties:
+        bound:
+          description: >-
+            The entity ID bound value that bounds the returned entity ID's.
+          type: integer
+          format: int64
+          nullable: false
+        boundType:
+          description: >-
+            The `SzBoundType` associated with the `bound` value to describe
+            how the bound was applied.
+          $ref: '#/components/schemas/SzBoundType'
+          nullable: false
+        pageSize:
+          description: >-
+            The requested page size representing the maximum number of 
+            entity ID's that were requested to be returned.
+          type: integer
+          format: int32
+          nullable: false
+        totalEntityCount:
+          description: >-
+            The total number of entities representing the set of all 
+            possible results across all pages.
+          type: integer
+          format: int64
+          nullable: false
+        entityIds:
+          description: >-
+            An array of entity ID's identifying the entities for the page.
+          type: array
+          items:
+            type: integer
+            format: int64
     SzCountStatsResponse:
       description: >-
         Extends the BaseResponse to add the fields for statistics representing
@@ -4853,6 +4983,9 @@ components:
         both in total and by data source.
       type: object
       required:
+        - totalRecordCount
+        - totalEntityCount
+        - totalUnmatchedRecordCount
         - dataSourceCounts
       properties:
         totalRecordCount:
@@ -4865,6 +4998,14 @@ components:
           description: >-
             The total number of entities that have been resolved from 
             the loaded records.
+          type: integer
+          format: int64
+          nullable: false
+        totalUnmatchedRecordCount:
+          description: >-
+            The total number of records that did not match against any 
+            other records and belong to singleton entities.  This doubles
+            as the count of all entities that only contain a single record.
           type: integer
           format: int64
           nullable: false
@@ -4882,6 +5023,8 @@ components:
       type: object
       required:
         - dataSourceCode
+        - recordCount
+        - entityCount
       properties:
         dataSourceCode:
           description: >-
@@ -4903,6 +5046,76 @@ components:
           type: integer
           format: int64
           nullable: false
+        unmatchedRecordCount:
+          description: >-
+            The total number of records that have been loaded for the associated
+            data source that did *NOT* match against any other records.  This 
+            represents the number of entities having a record from this data source
+            where that is the *ONLY* (single) record in the entity.
+          type: integer
+          format: int64
+          nullable: false
+    SzEntitySizeCountResponse:
+      description: >-
+        Extends the BaseResponse to add the fields for statistics representing
+        the number of entities having a specific composite record count.
+      allOf:
+        - $ref: '#/components/schemas/SzBaseResponse'
+        - type: object
+          properties:
+            data:
+              description: >-
+                The data field is the `SzEntitySizeCount` containing the
+                statistics.
+              $ref: '#/components/schemas/SzEntitySizeCount'
+    SzEntitySizeBreakdownResponse:
+      description: >-
+        Extends the BaseResponse to add the fields for statistics representing
+        counts of entities having each distinct composite number of records.
+      allOf:
+        - $ref: '#/components/schemas/SzBaseResponse'
+        - type: object
+          properties:
+            data:
+              description: >-
+                The data field is the `SzEntitySizeBreakdown` containing the
+                statistics.
+              $ref: '#/components/schemas/SzEntitySizeBreakdown'
+    SzEntitySizeCount:
+      description: >-
+        Describes the number of entities that have a specific number of
+        records.
+      type: object
+      required:
+        - recordCount
+        - entityCount
+      properties:
+        recordCount:
+          description: The number of records that the entities have.
+          type: integer
+          format: int32
+          nullable: false
+        entityCount:
+          description: >-
+            The number of entities having the associated number of records.
+          type: integer
+          format: int64
+          nullable: false
+    SzEntitySizeBreakdown:
+      description: >-
+        Describes the Entity Size Breakdown which gives the number of
+        entities having each entity size (i.e.: number of composite
+        records).
+      type: object
+      required:
+        - entitySizeCounts
+      properties:
+        entitySizeCounts:
+          description: >-
+            The array of `EntitySizeCount` instances describing the number
+            of entities having each number of composite records.  If there
+            are no entities having a specific composite record count then 
+            no entry is included in the array for that entity size.
     SzError:
       description: >-
         Describes an error.
@@ -5116,6 +5329,28 @@ components:
         - BRIEF
         - SUMMARY
         - VERBOSE
+    SzBoundType:
+      description: >-
+        Describes the type of bound for a range.
+        Possible values are:
+          * `INCLUSIVE_LOWER` - The bound represents an inclusive lower bound whereby
+                                values satisifying the bound will be greater-than or equal
+                                to the value associated with the bound.
+          * `EXCLUSIVE_LOWER` - The bound represents an exclusive lower bound whereby 
+                                values satisfying the bound will be strictly greater-than 
+                                the value associated with the bound.
+          * `INCLUSIVE_UPPER` - The bound represents an inclusive upper bound whereby
+                                values satisifying the bound will be less-than or equal
+                                to the value associated with the bound.
+          * `EXCLUSIVE_UPPER` - The bound represents an exclusive upper bound whereby 
+                                values satisfying the bound will be strictly less-than 
+                                the value associated with the bound.
+      type: string
+      enum:
+        - INCLUSIVE_LOWER
+        - EXCLUSIVE_LOWER
+        - INCLUSIVE_UPPER
+        - EXCLUSIVE_UPPER
     SzAttributeType:
       description: >-
         Describes an attribute type that partially (or fully) describes a

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -4949,6 +4949,7 @@ components:
         entityIds:
           description: >-
             An array of entity ID's identifying the entities for the page.
+            The entity ID array will be in ascending order.
           type: array
           items:
             type: integer
@@ -5087,10 +5088,10 @@ components:
         records.
       type: object
       required:
-        - recordCount
+        - entitySize
         - entityCount
       properties:
-        recordCount:
+        entitySize:
           description: The number of records that the entities have.
           type: integer
           format: int32
@@ -5115,7 +5116,8 @@ components:
             The array of `EntitySizeCount` instances describing the number
             of entities having each number of composite records.  If there
             are no entities having a specific composite record count then 
-            no entry is included in the array for that entity size.
+            no entry is included in the array for that entity size.  The
+            array will be in descending order of entity size.
     SzError:
       description: >-
         Describes an error.

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -2824,7 +2824,7 @@ paths:
                 $ref: '#/components/schemas/SzErrorResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/counts:
+  /statistics/loaded:
     get:
       tags:
         - Statistics
@@ -2851,7 +2851,7 @@ paths:
                 $ref: '#/components/schemas/SzCountStatsResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/counts/data-sources/{dataSourceCode}:
+  /statistics/loaded/data-sources/{dataSourceCode}:
     get:
       tags:
         - Statistics
@@ -2880,7 +2880,7 @@ paths:
                 $ref: '#/components/schemas/SzSourceCountStatsResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/entity-sizes/counts:
+  /statistics/sizes:
     get:
       tags:
         - Statistics
@@ -2906,7 +2906,7 @@ paths:
                 $ref: '#/components/schemas/SzEntitySizeBreakdownResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/entity-sizes/{entitySize}/count:
+  /statistics/sizes/{entitySize}:
     get:
       tags:
         - Statistics
@@ -2937,7 +2937,7 @@ paths:
                 $ref: '#/components/schemas/SzEntitySizeCountResponse'
         '500':
           $ref: '#/components/responses/ServerError'
-  /statistics/entity-sizes/{entitySize}/entities:
+  /statistics/sizes/{entitySize}/entities:
     get:
       tags:
         - Statistics
@@ -2953,7 +2953,7 @@ paths:
         returned but the array of ID's contained in the response will be empty.
         *NOTE*: Data mart statistics may be slightly delayed from the entity
         repository.        
-      operationId: getSourceRecordCountStatistics
+      operationId: getEntityIdsForEntitySize
       parameters:
         - $ref: '#/components/parameters/entitySizePathParam'
         - $ref: '#/components/parameters/entityIdBoundQueryParam'

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -4946,6 +4946,20 @@ components:
           type: integer
           format: int64
           nullable: false
+        beforeEntityCount:
+          description: >-
+            The number of entities in the set that exist on pages before 
+            this page.
+          type: integer
+          format: int64
+          nullable: false
+        afterEntityCount:
+          description: >-
+            The number of entities in the set that exist on pages after
+            this page.
+          type: integer
+          format: int64
+          nullable: false
         entityIds:
           description: >-
             An array of entity ID's identifying the entities for the page.

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Senzing POC REST API
-  version: "3.3.0"
+  version: "3.4.0"
   description: >-
     This is the Senzing POC REST API.  This API is <b>NOT</b> maintained for
     backwards compatibility.  This API extends the

--- a/senzing-poc-rest-api.yaml
+++ b/senzing-poc-rest-api.yaml
@@ -2824,6 +2824,170 @@ paths:
                 $ref: '#/components/schemas/SzErrorResponse'
         '500':
           $ref: '#/components/responses/ServerError'
+  /statistics/counts:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the entity and record counts in total and by data source from the
+        data mart.
+      description: >-
+        Gets the entity and record counts in total and by data source from the
+        data mart.  *NOTE*: Data mart statistics may be slightly delayed from 
+        the entity repository.
+      operationId: getCountStatistics
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /statistics/counts/entities:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the entity counts in total and by data source from the data mart.
+      description: >-
+        Gets the entity counts in total and by data source from the data mart.
+        *NOTE*: Data mart statistics may be slightly delayed from the entity
+        repository.
+      operationId: getEntityCountStatistics
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /statistics/counts/records:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the record counts in total and by data source from the data mart.
+      description: >-
+        Gets the record counts in total and by data source from the data mart.
+        *NOTE*: Data mart statistics may be slightly delayed from the entity
+        repository.
+      operationId: getRecordCountStatistics
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzCountStatsResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /statistics/counts/data-sources/{dataSourceCode}:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the entity and record counts for a specific data source from the
+        data mart.
+      description: >-
+        Gets the entity and record counts for a specific data source from the
+        data mart.  *NOTE*: Data mart statistics may be slightly delayed from 
+        the entity repository.
+      operationId: getSourceCountStatistics
+      parameters:
+        - $ref: '#/components/parameters/dataSourceCodePathParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /statistics/counts/data-sources/{dataSourceCode}/entities:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the entity counts for a specific data source from the data mart.
+      description: >-
+        Gets the entity counts for a specific data source from the data mart.
+        *NOTE*: Data mart statistics may be slightly delayed from the entity
+        repository.
+      operationId: getSourceEntityCountStatistics
+      parameters:
+        - $ref: '#/components/parameters/dataSourceCodePathParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /statistics/counts/data-sources/{dataSourceCode}/records:
+    get:
+      tags:
+        - Statistics
+      summary: >-
+        Gets the records counts for a specific data source from the data mart.
+      description: >-
+        Gets the record counts for a specific data source from the data mart.
+        *NOTE*: Data mart statistics may be slightly delayed from the entity
+        repository.
+      operationId: getSourceRecordCountStatistics
+      parameters:
+        - $ref: '#/components/parameters/dataSourceCodePathParam'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json; charset=UTF-8:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+            default:
+              schema:
+                $ref: '#/components/schemas/SzSourceCountStatsResponse'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /load-queue:
     get:
       tags:
@@ -2832,6 +2996,7 @@ paths:
         Gets the properties of the configured load queue.
       description: >-
         Obtains the properties of the configured load queue
+      deprecated: true
       operationId: getLoadQueueInfo
       responses:
         '200':
@@ -2880,6 +3045,7 @@ paths:
 
         **NOTE:** The actual loading of the record must be handled externally
         by a consumer of the messages on the configured load queue.
+      deprecated: true
       operationId: postRecordToLoadQueue
       parameters:
         - $ref: '#/components/parameters/dataSourceCodePathParam'
@@ -2997,6 +3163,7 @@ paths:
         **NOTE:** The actual loading of the record must be handled externally
         by a consumer of the messages on the configured load queue.
       operationId: putRecordOnLoadQueue
+      deprecated: true
       parameters:
         - $ref: '#/components/parameters/dataSourceCodePathParam'
         - $ref: '#/components/parameters/recordIdPathParam'
@@ -3146,6 +3313,7 @@ paths:
         number of seconds specified by the `eofSendTimeout` query parameter have
         elapsed without a new message being received.
       operationId: streamLoadBulkRecords
+      deprecated: true
       parameters:
         - name: dataSource
           description: |
@@ -4655,6 +4823,86 @@ components:
                   type: array
                   items:
                     $ref: '#/components/schemas/SzEntityData'
+    SzCountStatsResponse:
+      description: >-
+        Extends the BaseResponse to add the fields for statistics representing
+        counts of entities and records in total and by data source.
+      allOf:
+        - $ref: '#/components/schemas/SzBaseResponse'
+        - type: object
+          properties:
+            data:
+              description: >-
+                The data field is the `SzCountStats` containing the statistics.
+              $ref: '#/components/schemas/SzCountStats'
+    SzSourceCountStatsResponse:
+      description: >-
+        Extends the BaseResponse to add the fields for statistics representing
+        counts of entities and records for a specific data source.
+      allOf:
+        - $ref: '#/components/schemas/SzBaseResponse'
+        - type: object
+          properties:
+            data:
+              description: >-
+                The data field is the `SzSourceCountStats` containing the statistics.
+              $ref: '#/components/schemas/SzSourceCountStats'
+    SzCountStats:
+      description: >-
+        Encapsulates the statistics pertaining to counts of entities and records
+        both in total and by data source.
+      type: object
+      required:
+        - dataSourceCounts
+      properties:
+        totalRecordCount:
+          description: >-
+            The total number of records that have been loaded.
+          type: integer
+          format: int64
+          nullable: false
+        totalEntityCount:
+          description: >-
+            The total number of entities that have been resolved from 
+            the loaded records.
+          type: integer
+          format: int64
+          nullable: false
+        dataSourceCounts:
+          description: >-
+            An array of `SzSourceCountStats` describing the entity and record
+            counts by data source.
+          type: array
+          items:
+            $ref: '#/components/schemas/SzSourceCountStats'
+    SzSourceCountStats:
+      description: >-
+        Encapsulates the statistics pertaining to counts of entities and records
+        for a specific data source.
+      type: object
+      required:
+        - dataSourceCode
+      properties:
+        dataSourceCode:
+          description: >-
+            The data source code identifying the data source to which the statistics
+            are associated.
+          type: string
+          nullable: false
+        recordCount:
+          description: >-
+            The total number of records that have been loaded for the associated
+            data source.
+          type: integer
+          format: int64
+          nullable: false
+        entityCount:
+          description: >-
+            The number of entities that have at least one record from the 
+            associated data source.
+          type: integer
+          format: int64
+          nullable: false
     SzError:
       description: >-
         Describes an error.

--- a/src/main/java/com/senzing/poc/BuildInfo.java
+++ b/src/main/java/com/senzing/poc/BuildInfo.java
@@ -16,7 +16,7 @@ public class BuildInfo {
   /**
    * The POC REST API specification version implemented by the API Server.
    */
-  public static final String POC_REST_API_VERSION = "3.3.0";
+  public static final String POC_REST_API_VERSION = "3.4.0";
 
   static {
     String resource = "/com/senzing/poc/build-info.properties";

--- a/src/main/java/com/senzing/poc/model/SzBoundType.java
+++ b/src/main/java/com/senzing/poc/model/SzBoundType.java
@@ -1,0 +1,164 @@
+package com.senzing.poc.model;
+
+import java.lang.Comparable;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Enumnerates the various types of bounds that can be applied as
+ * criteria for a value having an ordering.
+ */
+public enum SzBoundType {
+    /**
+     * Describes a bound that is a lower bound that includes the
+     * bound value.  Values that satisfy such a bound are greater
+     * than or equal to the bound value.
+     */
+    INCLUSIVE_LOWER(true, true),
+
+    /**
+     * Describes a bound that is a lower bound that excludes the 
+     * bound value.  Values that satisfy such a bound are strictly
+     * greater than the bound value.
+     */
+    EXCLUSIVE_LOWER(false, true),
+
+    /**
+     * Describes a bound that is an upper bound that includes the
+     * bound value.  Values that satisfy such a bound are less than
+     * or equal to the bound value.
+     */
+    INCLUSIVE_UPPER(true, false),
+
+    /**
+     * Describes a bound that is an upper bound that excludes the 
+     * bound value.  Values that satisfy such a bound are strictly
+     * less than the bound value.
+     */
+    EXCLUSIVE_UPPER(false, false);
+
+    /**
+     * Flag indicating if this instance is inclusive.  If
+     * <code>true</code> then it is inclusive, otherwise if
+     * <code>false</code> then the bound type is exclusive.
+     */
+    private boolean inclusive = false;
+
+    /**
+     * Flag indicating fi this instance is a lower bound.  If
+     * <code>true</code> then it is a lower bound, otherwise if
+     * <code>false</code> then it is an upper bound.
+     */
+    private boolean lower = false;
+
+    /**
+     * Private constructor that constructs with the inclusivity and
+     * direction of the bound type.
+     * 
+     * @param inclusive <code>true</code> if the bound is inclusive,
+     *                  and <code>false</code> if it is exclusive.
+     * @param lower <code>true</code> if the bound is a lower bound,
+     *              and <code>false</code> if it is an upper bound.
+     */
+    SzBoundType(boolean inclusive, boolean lower) {
+        this.inclusive  = inclusive;
+        this.lower      = lower;
+    }
+
+    /**
+     * Checks if this instance describes an inclusive bound.
+     * 
+     * @return <code>true</code> if this instance describes an
+     *         inclusive bound, otherwise <code>false</code>
+     */
+    public boolean isInclusive() {
+        return this.inclusive;
+    }
+
+    /**
+     * Checks if this instance describes an exclusive bound.
+     * 
+     * @return <code>true</code> if this instance describes an
+     *         exclusive bound, otherwise <code>false</code>
+     */
+    public boolean isExclusive() {
+        return (!this.isInclusive());
+    }
+
+    /**
+     * Checks if this instance describes a lower bound.
+     * 
+     * @return <code>true</code. if this instance describes a
+     *         lower bound, otherwise <code>false</code>.
+     */
+    public boolean isLower() {
+        return this.lower;
+    }
+
+    /**
+     * Checks if this instance describes an upper bound.
+     * 
+     * @return <code>true</code. if this instance describes an
+     *         upper bound, otherwise <code>false</code>.
+     */
+    public boolean isUpper() {
+        return (!this.isLower());
+    }
+
+    /**
+     * Compares the two specified values and returns <code>true</code> if
+     * the specified value satisfies the bound the defined by this {@link
+     * SzBoundType} instance and the specified bound value.
+     * 
+     * @param value The value to check if it satisfies the bound.
+     * @param boundValue The bound value to couple with this {@link 
+     *                   SzBoundType} instance to define the bound.
+     * 
+     * @return <code>true</code> if the value satisfies the bound, otherwise
+     *         <code>false</code>
+     * 
+     * @throws NullPointerException If either of the specified values is 
+     *                              <code>null</code>.
+     */
+    public boolean checkSatisfies(Comparable value, Comparable boundValue) 
+        throws NullPointerException
+    {
+        Objects.requireNonNull(value, "The specified value cannot be null");
+        Objects.requireNonNull(boundValue, "The specified bound value cannot be null");
+        int compare = value.compareTo(boundValue);
+        if (compare == 0) return this.isInclusive();
+        if (compare > 0) return this.isLower();
+        return this.isUpper();
+    }
+
+    /**
+     * Compares the two specified values and returns <code>true</code> if
+     * the specified value satisfies the bound the defined by this {@link
+     * SzBoundType} instance and the specified bound value.
+     * 
+     * @param value The value to check if it satisfies the bound.
+     * @param boundValue The bound value to couple with this {@link 
+     *                   SzBoundType} instance to define the bound.
+     * @param comparator The {@link Comparator} to use for comparing the values.
+     * 
+     * @param <T> The type of the objects being compared.
+     * 
+     * @return <code>true</code> if the value satisfies the bound, otherwise
+     *         <code>false</code>
+     * 
+     * @throws NullPointerException If either of the specified values is 
+     *                              <code>null</code> or if the specified 
+     *                              {@link Comparator} is <code>null</code>.
+     */
+    public <T> boolean checkSatisfies(T value, T boundValue, Comparator<T> comparator)
+        throws NullPointerException
+    {
+        Objects.requireNonNull(value, "The specified value cannot be null");
+        Objects.requireNonNull(boundValue, "The specified bound value cannot be null");
+        Objects.requireNonNull(comparator, "The specified comparator cannot be null");
+        int compare = comparator.compare(value, boundValue);
+        if (compare == 0) return this.isInclusive();
+        if (compare > 0) return this.isLower();
+        return this.isUpper();
+    }
+}

--- a/src/main/java/com/senzing/poc/model/SzCountStats.java
+++ b/src/main/java/com/senzing/poc/model/SzCountStats.java
@@ -90,7 +90,7 @@ public interface SzCountStats {
    * count statistics for each data source.  This clears any existing 
    * data source counts before setting with those specified.   The specified
    * {@link List} should contain only one element for each data source, but
-   * uf duplicates are encountered then later values in the {@link List}
+   * if duplicates are encountered then later values in the {@link List}
    * take precedence, overwriting prior values from the {@link List}.
    * Specifying a <code>null</code> {@link List} is equivalent to specifying
    * an empty {@link List}.

--- a/src/main/java/com/senzing/poc/model/SzCountStats.java
+++ b/src/main/java/com/senzing/poc/model/SzCountStats.java
@@ -1,0 +1,168 @@
+package com.senzing.poc.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.AbstractModelProvider;
+import com.senzing.api.model.ModelFactory;
+import com.senzing.api.model.ModelProvider;
+import com.senzing.poc.model.impl.SzCountStatsImpl;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Describes a count statistics for the repository.
+ */
+@JsonDeserialize(using = SzCountStats.Factory.class)
+public interface SzCountStats {
+  /**
+   * Gets the total number of records that have been loaded to the 
+   * entity repository.  This returns <code>null</code> if the record
+   * count was not requested and has not been initialized.
+   *
+   * @return The total number of records that have been loaded to the
+   *         entity repository, or <code>null</code> if the record
+   *         count was not requested and has not been initialized.
+   */
+  @JsonInclude(NON_NULL)
+  Long getTotalRecordCount();
+
+  /**
+   * Sets the the total number of records that have been loaded to the
+   * entity repository.
+   *
+   * @param recordCount The total number of records that have been loaded
+   *                    to the entity repository.
+   */
+  void setTotalRecordCount(long recordCount);
+
+  /**
+   * Gets the total number of entities that have been resolved in the
+   * entity repository.  This returns <code>null</code> if the entity
+   * count was not requested and has not been initialized.
+   *
+   * @return The total number of entities that have been resolved in the
+   *         entity repository, or <code>null</code> if the entity count
+   *         was not requested and has not been initialized.
+   */
+  @JsonInclude(NON_NULL)
+  Long getTotalEntityCount();
+
+  /**
+   * Sets total number of entities that have at least one record from
+   * the associated data source.
+   *
+   * @param entityCount The total number of entities that have been loaded
+   *                    for the associated data source.
+   */
+  void setTotalEntityCount(long entityCount);
+
+  /**
+   * Gets the {@link List} of {@link SzSourceCountStats} describing the 
+   * count statistics for each data source.  The returned value list sould
+   * contain only one element for each data source.
+   * 
+   * @return The {@link List} of {@link SzSourceCountStats} describing the 
+   *         count statistics for each data source.  The returned {@link List}
+   *         sould contain only one element for each data source.
+   */
+  List<SzSourceCountStats> getDataSourceCounts();
+
+  /**
+   * Sets the {@link List} of {@link SzSourceCountStats} describing the 
+   * count statistics for each data source.  This clears any existing 
+   * data source counts before setting with those specified.   The specified
+   * {@link List} should contain only one element for each data source, but
+   * uf duplicates are encountered then later values in the {@link List}
+   * take precedence, overwriting prior values from the {@link List}.
+   * Specifying a <code>null</code> {@link List} is equivalent to specifying
+   * an empty {@link List}.
+   * 
+   * @param statsList The {@link List} of {@link SzSourceCountStats} 
+   *                  describing the count statistics for each data source.
+   */
+  void setDataSourceCounts(List<SzSourceCountStats> statsList);
+
+  /**
+   * Adds the specified {@link SzSourceCountStats} describing count statistics
+   * for a data source to the existing {@link SzSourceCountStats} for this 
+   * instance.  If the specified {@link SzSourceCountStats} has the same 
+   * data source code as an existing {@link SzSourceCountStats} instance then
+   * the specified value replaces the existing one for that data source code.
+   * 
+   * @param stats The {@link SzSourceCountStats} describing count statistics
+   *              for a specific data source.
+   */
+  void addDataSourceCount(SzSourceCountStats stats);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzCountStats}.
+   */
+  interface Provider extends ModelProvider<SzCountStats> {
+    /**
+     * Creates a new instance of {@link SzCountStats}.
+     * 
+     * @return The new instance of {@link SzCountStats}
+     */
+    SzCountStats create();
+  }
+
+  /**
+   * Provides a default {@link Provider} implementation for {@link SzCountStats}
+   * that produces instances of {@link SzCountStatsImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzCountStats>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzCountStats.class, SzCountStatsImpl.class);
+    }
+
+    @Override
+    public SzCountStats create() {
+      return new SzCountStatsImpl();
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for {@link SzCountStats}.
+   */
+  class Factory extends ModelFactory<SzCountStats, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzCountStats.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates a new instance of {@link SzCountStats}.
+     * 
+     * @return The new instance of {@link SzCountStats}
+     */
+    public SzCountStats create()
+    {
+      return this.getProvider().create();
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzCountStats.java
+++ b/src/main/java/com/senzing/poc/model/SzCountStats.java
@@ -18,15 +18,12 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public interface SzCountStats {
   /**
    * Gets the total number of records that have been loaded to the 
-   * entity repository.  This returns <code>null</code> if the record
-   * count was not requested and has not been initialized.
+   * entity repository.
    *
    * @return The total number of records that have been loaded to the
-   *         entity repository, or <code>null</code> if the record
-   *         count was not requested and has not been initialized.
+   *         entity repository.
    */
-  @JsonInclude(NON_NULL)
-  Long getTotalRecordCount();
+  long getTotalRecordCount();
 
   /**
    * Sets the the total number of records that have been loaded to the
@@ -39,15 +36,12 @@ public interface SzCountStats {
 
   /**
    * Gets the total number of entities that have been resolved in the
-   * entity repository.  This returns <code>null</code> if the entity
-   * count was not requested and has not been initialized.
+   * entity repository.
    *
    * @return The total number of entities that have been resolved in the
-   *         entity repository, or <code>null</code> if the entity count
-   *         was not requested and has not been initialized.
+   *         entity repository.
    */
-  @JsonInclude(NON_NULL)
-  Long getTotalEntityCount();
+  long getTotalEntityCount();
 
   /**
    * Sets total number of entities that have at least one record from
@@ -57,6 +51,28 @@ public interface SzCountStats {
    *                    for the associated data source.
    */
   void setTotalEntityCount(long entityCount);
+
+  /**
+   * Gets the total number of records that have been loaded to the 
+   * entity repository that did <b>not</b> match against any other
+   * records.   This is also the total number of entities that only
+   * have a single record.
+   *
+   * @return The total number of records that have been loaded to the
+   *         entity repository.
+   */
+  long getTotalUnmatchedRecordCount();
+
+  /**
+   * Sets the the total number of records that have been loaded to the
+   * entity repository that did <b>not</b> match against any other
+   * record.  This is also the total number of entities that only have
+   * a single record.
+   *
+   * @param recordCount The total number of records that have been loaded
+   *                    to the entity repository.
+   */
+  void setTotalUnmatchedRecordCount(long recordCount);
 
   /**
    * Gets the {@link List} of {@link SzSourceCountStats} describing the 

--- a/src/main/java/com/senzing/poc/model/SzCountStatsResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzCountStatsResponse.java
@@ -4,7 +4,7 @@ import com.senzing.api.model.*;
 import com.senzing.poc.model.impl.SzCountStatsResponseImpl;
 
 /**
- * Describes a response when queue info is requested.
+ * Describes a response when count statistics are requested.
  */
 public interface SzCountStatsResponse extends SzBasicResponse {
   /**

--- a/src/main/java/com/senzing/poc/model/SzCountStatsResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzCountStatsResponse.java
@@ -1,0 +1,142 @@
+package com.senzing.poc.model;
+
+import com.senzing.api.model.*;
+import com.senzing.poc.model.impl.SzCountStatsResponseImpl;
+
+/**
+ * Describes a response when queue info is requested.
+ */
+public interface SzCountStatsResponse extends SzBasicResponse {
+  /**
+   * Returns the {@link SzCountStats} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  SzCountStats getData();
+
+  /**
+   * Sets the data associated with this response with an {@link SzCountStats}.
+   *
+   * @param info The {@link SzCountStats} describing the statistics.
+   */
+  void setData(SzCountStats info);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzCountStatsResponse}.
+   */
+  interface Provider extends ModelProvider<SzCountStatsResponse> {
+    /**
+     * Constructs with only the {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    SzCountStatsResponse create(SzMeta meta, SzLinks links);
+
+    /**
+     * Creates an instance with the specified {@liink SzMeta}, {@link SzLinks}
+     * and {@link SzCountStats}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param countStats The {@link SzCountStats} describing the data for this 
+     *                  instance.
+     */
+    SzCountStatsResponse create(SzMeta          meta,
+                                SzLinks         links,
+                                SzCountStats    countStats);
+  }
+  
+  /**
+   * Provides a default {@link Provider} implementation for {@link
+   * SzCountStatsResponse} that produces instances of
+   * {@link SzCountStatsResponseImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzCountStatsResponse>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzCountStatsResponse.class,
+            SzCountStatsResponseImpl.class);
+    }
+
+    @Override
+    public SzCountStatsResponse create(SzMeta meta, SzLinks links){
+      return new SzCountStatsResponseImpl(meta, links);
+    }
+
+    @Override
+    public SzCountStatsResponse create(SzMeta       meta,
+                                       SzLinks      links,
+                                       SzCountStats countStats)
+    {
+      return new SzCountStatsResponseImpl(meta, links, countStats);
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for
+   * {@link SzCountStatsResponse}.
+   */
+  class Factory extends ModelFactory<SzCountStatsResponse, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzCountStatsResponse.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates an instance of {@link SzCountStatsResponse} with the
+     * specified {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    public SzCountStatsResponse create(SzMeta meta, SzLinks links) {
+      return this.getProvider().create(meta, links);
+    }
+
+    /**
+     * Creates an instance of {@link SzCountStatsResponse} with the
+     * specified {@link SzMeta}, {@link SzLinks} and the speicified {@link
+     * SzCountStats} describing the bulk records.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param CountStats The {@link SzCountStats} describing the
+     *                     bulk records.
+     */
+    public SzCountStatsResponse create(SzMeta       meta,
+                                       SzLinks      links,
+                                       SzCountStats countStats)
+    {
+      return this.getProvider().create(meta, links, countStats);
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzEntitiesPage.java
+++ b/src/main/java/com/senzing/poc/model/SzEntitiesPage.java
@@ -1,0 +1,231 @@
+package com.senzing.poc.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.AbstractModelProvider;
+import com.senzing.api.model.ModelFactory;
+import com.senzing.api.model.ModelProvider;
+import com.senzing.poc.model.impl.SzEntitiesPageImpl;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Describes a count statistics for the repository.
+ */
+@JsonDeserialize(using = SzEntitiesPage.Factory.class)
+public interface SzEntitiesPage {
+  /**
+   * Gets the entity ID bound value that bounds the included
+   * entity ID's.
+   *
+   * @return The entity ID bound value that bounds the included
+   *         entity ID's.
+   */
+  long getBound();
+
+  /**
+   * Sets the entity ID bound value that bounds the included
+   * entity ID's.
+   *
+   * @param bound The entity ID bound value that bounds the
+   *              included entity ID's.
+   */
+  void setBound(long bound);
+
+  /**
+   * Gets the {@link SzBoundType} that describes how the associated
+   * {@linkplain #getBound() bound value} was applied.
+   *
+   * @return The the {@link SzBoundType} that describes how the
+   *         associated {@linkplain #getBound() bound value} was
+   *         applied.
+   */
+  SzBoundType getBoundType();
+
+  /**
+   * Sets the {@link SzBoundType} that describes how the associated
+   * {@linkplain #getBound() bound value} was applied.
+   *
+   * @param boundType The the {@link SzBoundType} that describes how
+   *                  the associated {@linkplain #getBound() bound 
+   *                  value} was applied.
+   */
+  void setBoundType(SzBoundType boundType);
+
+  /**
+   * Gets requested page size representing the maximum number of
+   * entity ID's that were requested to be returned.
+   * 
+   * @return The equested page size representing the maximum number
+   *         of entity ID's that were requested to be returned.
+   */
+  int getPageSize();
+
+  /**
+   * Sets requested page size representing the maximum number of
+   * entity ID's that were requested to be returned.
+   * 
+   * @param pageSize The equested page size representing the 
+   *                 maximum number of entity ID's that were
+   *                 requested to be returned.
+   */
+  void setPageSize(int pageSize);
+
+  /**
+   * Gets the total number of entities in the set representing
+   * the set of all possible results across all pages.
+   *
+   * @return The the total number of entities in the set
+   *         representing the set of all possible results
+   *         across all pages.
+   */
+  long getTotalEntityCount();
+
+  /**
+   * Sets the total number of entities in the set representing
+   * the set of all possible results across all pages.
+   *
+   * @param count The the total number of entities in the set
+   *              representing the set of all possible results
+   *              across all pages.
+   */
+  void setTotalEntityCount(long count);
+
+  /**
+   * Gets the number of entities in the set that exist on
+   * pages that occur before this page.
+   * 
+   * @return The the number of entities in the set that exist
+   *         on pages that occur before this page.
+   */
+  long getBeforeEntityCount();
+
+  /**
+   * Sets the number of entities in the set that exist on
+   * pages that occur before this page.
+   * 
+   * @param count The the number of entities in the set that 
+   *              exist on pages that occur before this page.
+   */
+  void setBeforeEntityCount(long count);
+
+  /**
+   * Gets the number of entities in the set that exist on
+   * pages that occur after this page.
+   * 
+   * @return The the number of entities in the set that exist
+   *         on pages that occur after this page.
+   */
+  long getAfterEntityCount();
+
+  /**
+   * Sets the number of entities in the set that exist on
+   * pages that occur after this page.
+   * 
+   * @param count The the number of entities in the set that 
+   *              exist on pages that occur after this page.
+   */
+  void setAfterEntityCount(long count);
+
+  /**
+   * Gets the {@link List} of {@link Long} entity Id's identifying the 
+   * entities in this page of results.  The returned {@link List} will
+   * be in ascending order.
+   * 
+   * @return The {@link List} of {@link Long} entity Id's identifying
+   *         the entities in this page of results (in ascending order).
+   */
+  List<Long> getEntityIds();
+
+  /**
+   * Sets the {@link List} of {@link Long} entity Id's identifying the 
+   * entities in this page of results.  The entity IDs will be sorted
+   * and deduplicated when added to this instance.
+   * 
+   * @param entityIdList The {@link List} of {@link Long} entity Id's 
+   *                     identifying the entities in this page of results.
+    */
+  void setEntityIds(List<Long> entityIdList);
+
+  /**
+   * Adds the specified entity ID to the list of entities for this page.
+   * If the specified entity ID is already included, then this method
+   * has no effect.
+   * 
+   * @param entityId The entity ID to add to the list of entities for 
+   *                 this page.
+   */
+  void addEntityId(long entityId);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzEntitiesPage}.
+   */
+  interface Provider extends ModelProvider<SzEntitiesPage> {
+    /**
+     * Creates a new instance of {@link SzEntitiesPage}.
+     * 
+     * @return The new instance of {@link SzEntitiesPage}
+     */
+    SzEntitiesPage create();
+  }
+
+  /**
+   * Provides a default {@link Provider} implementation for {@link SzEntitiesPage}
+   * that produces instances of {@link SzEntitiesPageImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzEntitiesPage>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzEntitiesPage.class, SzEntitiesPageImpl.class);
+    }
+
+    @Override
+    public SzEntitiesPage create() {
+      return new SzEntitiesPageImpl();
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for {@link SzEntitiesPage}.
+   */
+  class Factory extends ModelFactory<SzEntitiesPage, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzEntitiesPage.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates a new instance of {@link SzEntitiesPage}.
+     * 
+     * @return The new instance of {@link SzEntitiesPage}
+     */
+    public SzEntitiesPage create()
+    {
+      return this.getProvider().create();
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzEntitiesPageResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzEntitiesPageResponse.java
@@ -1,0 +1,144 @@
+package com.senzing.poc.model;
+
+import com.senzing.api.model.*;
+import com.senzing.poc.model.impl.SzEntitiesPageResponseImpl;
+
+/**
+ * Describes a response when a page of entity ID's supporting a
+ * statistic is requested.
+ */
+public interface SzEntitiesPageResponse extends SzBasicResponse {
+  /**
+   * Returns the {@link SzEntitiesPage} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  SzEntitiesPage getData();
+
+  /**
+   * Sets the data associated with this response with an {@link SzEntitiesPage}.
+   *
+   * @param info The {@link SzEntitiesPage} describing the statistics.
+   */
+  void setData(SzEntitiesPage info);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzEntitiesPageResponse}.
+   */
+  interface Provider extends ModelProvider<SzEntitiesPageResponse> {
+    /**
+     * Constructs with only the {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    SzEntitiesPageResponse create(SzMeta meta, SzLinks links);
+
+    /**
+     * Creates an instance with the specified {@liink SzMeta}, {@link SzLinks}
+     * and {@link SzEntitiesPage}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param countStats The {@link SzEntitiesPage} describing the data for this 
+     *                  instance.
+     */
+    SzEntitiesPageResponse create(SzMeta          meta,
+                                  SzLinks         links,
+                                  SzEntitiesPage  countStats);
+  }
+  
+  /**
+   * Provides a default {@link Provider} implementation for {@link
+   * SzEntitiesPageResponse} that produces instances of
+   * {@link SzEntitiesPageResponseImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzEntitiesPageResponse>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzEntitiesPageResponse.class,
+            SzEntitiesPageResponseImpl.class);
+    }
+
+    @Override
+    public SzEntitiesPageResponse create(SzMeta meta, SzLinks links){
+      return new SzEntitiesPageResponseImpl(meta, links);
+    }
+
+    @Override
+    public SzEntitiesPageResponse create(SzMeta       meta,
+                                       SzLinks      links,
+                                       SzEntitiesPage countStats)
+    {
+      return new SzEntitiesPageResponseImpl(meta, links, countStats);
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for
+   * {@link SzEntitiesPageResponse}.
+   */
+  class Factory extends ModelFactory<SzEntitiesPageResponse, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzEntitiesPageResponse.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates an instance of {@link SzEntitiesPageResponse} with the
+     * specified {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    public SzEntitiesPageResponse create(SzMeta meta, SzLinks links) {
+      return this.getProvider().create(meta, links);
+    }
+
+    /**
+     * Creates an instance of {@link SzEntitiesPageResponse} with the
+     * specified {@link SzMeta}, {@link SzLinks} and the speicified {@link
+     * SzEntitiesPage} describing the bulk records.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param CountStats The {@link SzEntitiesPage} describing the
+     *                     bulk records.
+     */
+    public SzEntitiesPageResponse create(
+        SzMeta          meta,
+        SzLinks         links,
+        SzEntitiesPage  countStats)
+    {
+      return this.getProvider().create(meta, links, countStats);
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzEntitySizeBreakdown.java
+++ b/src/main/java/com/senzing/poc/model/SzEntitySizeBreakdown.java
@@ -1,0 +1,134 @@
+package com.senzing.poc.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.AbstractModelProvider;
+import com.senzing.api.model.ModelFactory;
+import com.senzing.api.model.ModelProvider;
+import com.senzing.poc.model.impl.SzEntitySizeBreakdownImpl;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Describes the number of entities in the entity repository at each 
+ * count statistics for the repository.
+ */
+@JsonDeserialize(using = SzEntitySizeBreakdown.Factory.class)
+public interface SzEntitySizeBreakdown {
+  /**
+   * Gets the {@link List} of {@link SzEntitySizeCount} describing the 
+   * number of entities having each entity size indicated by the number
+   * of constituent records for that entity.  The returned value list 
+   * should contain only one element for each distinct entity size that
+   * exists in the repository.  The {@link List} is returned in descending
+   * order of entity size.
+   * 
+   * @return The {@link List} of {@link SzEntitySizeCount} describing the 
+   *         number of entities having each entity size indicated by the
+   *         number of constituent records for that entity.
+   */
+  List<SzEntitySizeCount> getEntitySizeCounts();
+
+  /**
+   * Sets the {@link List} of {@link SzEntitySizeCount} describing the 
+   * number of entities having each entity size indicated by the number
+   * of constituent records for that entity.  This clears any existing 
+   * entity size counts before setting with those specified.   The specified
+   * {@link List} should contain only one element for each entity size, but
+   * if duplicates are encountered then later values in the {@link List}
+   * take precedence, overwriting prior values from the {@link List}.
+   * Specifying a <code>null</code> {@link List} is equivalent to specifying
+   * an empty {@link List}.
+   * 
+   * @param sizeCountList The {@link List} of {@link SzEntitySizeCount} 
+   *                      describing the number of entities having each
+   *                      entity size indicated by the number of
+   *                      constituent records for that entity.
+   */
+  void setEntitySizeCounts(List<SzEntitySizeCount> sizeCountList);
+
+  /**
+   * Adds the specified {@link SzEntitySizeCount} describing the number of
+   * entities in the entity repository having a specific entity size.  If
+   * the specified {@link SzEntitySizeCount} has the same entity size as
+   * an existing {@link SzEntitySizeCount} instance then the specified
+   * value replaces the existing one for that entity size.
+   * 
+   * @param sizeCount The {@link SzEntitySizeCount} describing the number
+   *                  of entities in the entity repository having a
+   *                  specific entity size.
+   */
+  void addEntitySizeCount(SzEntitySizeCount sizeCount);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzEntitySizeBreakdown}.
+   */
+  interface Provider extends ModelProvider<SzEntitySizeBreakdown> {
+    /**
+     * Creates a new instance of {@link SzEntitySizeBreakdown}.
+     * 
+     * @return The new instance of {@link SzEntitySizeBreakdown}
+     */
+    SzEntitySizeBreakdown create();
+  }
+
+  /**
+   * Provides a default {@link Provider} implementation for {@link SzEntitySizeBreakdown}
+   * that produces instances of {@link SzEntitySizeBreakdownImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzEntitySizeBreakdown>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzEntitySizeBreakdown.class, SzEntitySizeBreakdownImpl.class);
+    }
+
+    @Override
+    public SzEntitySizeBreakdown create() {
+      return new SzEntitySizeBreakdownImpl();
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for {@link SzEntitySizeBreakdown}.
+   */
+  class Factory extends ModelFactory<SzEntitySizeBreakdown, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzEntitySizeBreakdown.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates a new instance of {@link SzEntitySizeBreakdown}.
+     * 
+     * @return The new instance of {@link SzEntitySizeBreakdown}
+     */
+    public SzEntitySizeBreakdown create()
+    {
+      return this.getProvider().create();
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzEntitySizeBreakdownResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzEntitySizeBreakdownResponse.java
@@ -1,0 +1,143 @@
+package com.senzing.poc.model;
+
+import com.senzing.api.model.*;
+import com.senzing.poc.model.impl.SzEntitySizeBreakdownResponseImpl;
+
+/**
+ * Describes a response when an entity size breakdown is requested.
+ */
+public interface SzEntitySizeBreakdownResponse extends SzBasicResponse {
+  /**
+   * Returns the {@link SzEntitySizeBreakdown} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  SzEntitySizeBreakdown getData();
+
+  /**
+   * Sets the data associated with this response with an {@link SzEntitySizeBreakdown}.
+   *
+   * @param info The {@link SzEntitySizeBreakdown} describing the statistics.
+   */
+  void setData(SzEntitySizeBreakdown info);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzEntitySizeBreakdownResponse}.
+   */
+  interface Provider extends ModelProvider<SzEntitySizeBreakdownResponse> {
+    /**
+     * Constructs with only the {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    SzEntitySizeBreakdownResponse create(SzMeta meta, SzLinks links);
+
+    /**
+     * Creates an instance with the specified {@liink SzMeta}, {@link SzLinks}
+     * and {@link SzEntitySizeBreakdown}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param countStats The {@link SzEntitySizeBreakdown} describing the data for this 
+     *                  instance.
+     */
+    SzEntitySizeBreakdownResponse create(SzMeta                 meta,
+                                         SzLinks                links,
+                                         SzEntitySizeBreakdown  countStats);
+  }
+  
+  /**
+   * Provides a default {@link Provider} implementation for {@link
+   * SzEntitySizeBreakdownResponse} that produces instances of
+   * {@link SzEntitySizeBreakdownResponseImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzEntitySizeBreakdownResponse>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzEntitySizeBreakdownResponse.class,
+            SzEntitySizeBreakdownResponseImpl.class);
+    }
+
+    @Override
+    public SzEntitySizeBreakdownResponse create(SzMeta meta, SzLinks links){
+      return new SzEntitySizeBreakdownResponseImpl(meta, links);
+    }
+
+    @Override
+    public SzEntitySizeBreakdownResponse create(SzMeta       meta,
+                                       SzLinks      links,
+                                       SzEntitySizeBreakdown countStats)
+    {
+      return new SzEntitySizeBreakdownResponseImpl(meta, links, countStats);
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for
+   * {@link SzEntitySizeBreakdownResponse}.
+   */
+  class Factory extends ModelFactory<SzEntitySizeBreakdownResponse, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzEntitySizeBreakdownResponse.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates an instance of {@link SzEntitySizeBreakdownResponse} with the
+     * specified {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    public SzEntitySizeBreakdownResponse create(SzMeta meta, SzLinks links) {
+      return this.getProvider().create(meta, links);
+    }
+
+    /**
+     * Creates an instance of {@link SzEntitySizeBreakdownResponse} with the
+     * specified {@link SzMeta}, {@link SzLinks} and the speicified {@link
+     * SzEntitySizeBreakdown} describing the bulk records.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param CountStats The {@link SzEntitySizeBreakdown} describing the
+     *                     bulk records.
+     */
+    public SzEntitySizeBreakdownResponse create(
+        SzMeta                meta,
+        SzLinks               links,
+        SzEntitySizeBreakdown countStats)
+    {
+      return this.getProvider().create(meta, links, countStats);
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzEntitySizeCount.java
+++ b/src/main/java/com/senzing/poc/model/SzEntitySizeCount.java
@@ -1,0 +1,126 @@
+package com.senzing.poc.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.AbstractModelProvider;
+import com.senzing.api.model.ModelFactory;
+import com.senzing.api.model.ModelProvider;
+import com.senzing.poc.model.impl.SzEntitySizeCountImpl;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Describes a the number of entities having a specific entity size
+ * given by the {@linkplain #getEntitySize() record count}.
+ */
+@JsonDeserialize(using = SzEntitySizeCount.Factory.class)
+public interface SzEntitySizeCount {
+  /**
+   * Gets the number of records indicating the size of the entities
+   * for which the entity count is provided.
+   *
+   * @return The number of records indicating the size of the entities
+   *         for which the entity count is provided.
+   */
+  int getEntitySize();
+
+  /**
+   * Sets the number of records indicating the size of the entities
+   * for which the entity count is provided.
+   *
+   * @param recordCount The number of records indicating the size of the
+   *                    entities for which the entity count is provided.
+   */
+  void setEntitySize(int recordCount);
+
+  /**
+   * Gets number of entities in the entity repository having the associated
+   * {@linkplain #getEntitySize() entity size}.
+   *
+   * @return The number of entities in the entity repository having the
+   *         associated {@linkplain #getEntitySize() entity size}.
+   */
+  long getEntityCount();
+
+  /**
+   * Sets number of entities in the entity repository having the associated
+   * {@linkplain #getEntitySize() entity size}.
+   *
+   * @param entityCount The number of entities in the entity repository
+   *                    having the associated {@linkplain #getEntitySize() 
+   *                    entity size}.
+   */
+  void setEntityCount(long entityCount);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzEntitySizeCount}.
+   */
+  interface Provider extends ModelProvider<SzEntitySizeCount> {
+    /**
+     * Creates a new instance of {@link SzEntitySizeCount}.
+     * 
+     * @return The new instance of {@link SzEntitySizeCount}
+     */
+    SzEntitySizeCount create();
+  }
+
+  /**
+   * Provides a default {@link Provider} implementation for {@link SzEntitySizeCount}
+   * that produces instances of {@link SzEntitySizeCountImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzEntitySizeCount>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzEntitySizeCount.class, SzEntitySizeCountImpl.class);
+    }
+
+    @Override
+    public SzEntitySizeCount create() {
+      return new SzEntitySizeCountImpl();
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for {@link SzEntitySizeCount}.
+   */
+  class Factory extends ModelFactory<SzEntitySizeCount, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzEntitySizeCount.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates a new instance of {@link SzEntitySizeCount}.
+     * 
+     * @return The new instance of {@link SzEntitySizeCount}
+     */
+    public SzEntitySizeCount create()
+    {
+      return this.getProvider().create();
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzEntitySizeCountResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzEntitySizeCountResponse.java
@@ -1,0 +1,143 @@
+package com.senzing.poc.model;
+
+import com.senzing.api.model.*;
+import com.senzing.poc.model.impl.SzEntitySizeCountResponseImpl;
+
+/**
+ * Describes a response when an entity size count is requested.
+ */
+public interface SzEntitySizeCountResponse extends SzBasicResponse {
+  /**
+   * Returns the {@link SzEntitySizeCount} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  SzEntitySizeCount getData();
+
+  /**
+   * Sets the data associated with this response with an {@link SzEntitySizeCount}.
+   *
+   * @param info The {@link SzEntitySizeCount} describing the statistics.
+   */
+  void setData(SzEntitySizeCount info);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzEntitySizeCountResponse}.
+   */
+  interface Provider extends ModelProvider<SzEntitySizeCountResponse> {
+    /**
+     * Constructs with only the {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    SzEntitySizeCountResponse create(SzMeta meta, SzLinks links);
+
+    /**
+     * Creates an instance with the specified {@liink SzMeta}, {@link SzLinks}
+     * and {@link SzEntitySizeCount}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param countStats The {@link SzEntitySizeCount} describing the data for this 
+     *                  instance.
+     */
+    SzEntitySizeCountResponse create(SzMeta                 meta,
+                                         SzLinks                links,
+                                         SzEntitySizeCount  countStats);
+  }
+  
+  /**
+   * Provides a default {@link Provider} implementation for {@link
+   * SzEntitySizeCountResponse} that produces instances of
+   * {@link SzEntitySizeCountResponseImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzEntitySizeCountResponse>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzEntitySizeCountResponse.class,
+            SzEntitySizeCountResponseImpl.class);
+    }
+
+    @Override
+    public SzEntitySizeCountResponse create(SzMeta meta, SzLinks links){
+      return new SzEntitySizeCountResponseImpl(meta, links);
+    }
+
+    @Override
+    public SzEntitySizeCountResponse create(SzMeta            meta,
+                                            SzLinks           links,
+                                            SzEntitySizeCount countStats)
+    {
+      return new SzEntitySizeCountResponseImpl(meta, links, countStats);
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for
+   * {@link SzEntitySizeCountResponse}.
+   */
+  class Factory extends ModelFactory<SzEntitySizeCountResponse, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzEntitySizeCountResponse.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates an instance of {@link SzEntitySizeCountResponse} with the
+     * specified {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    public SzEntitySizeCountResponse create(SzMeta meta, SzLinks links) {
+      return this.getProvider().create(meta, links);
+    }
+
+    /**
+     * Creates an instance of {@link SzEntitySizeCountResponse} with the
+     * specified {@link SzMeta}, {@link SzLinks} and the speicified {@link
+     * SzEntitySizeCount} describing the bulk records.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param CountStats The {@link SzEntitySizeCount} describing the
+     *                     bulk records.
+     */
+    public SzEntitySizeCountResponse create(
+        SzMeta                meta,
+        SzLinks               links,
+        SzEntitySizeCount     countStats)
+    {
+      return this.getProvider().create(meta, links, countStats);
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzSourceCountStats.java
+++ b/src/main/java/com/senzing/poc/model/SzSourceCountStats.java
@@ -38,15 +38,12 @@ public interface SzSourceCountStats {
 
   /**
    * Gets the total number of records that have been loaded for the 
-   * associated data source.  This returns <code>null</code> if the record
-   * count was not requested and has not been initialized.
+   * associated data source.
    *
    * @return The total number of records that have been loaded for the 
-   *         associated data source, or <code>null</code> if the record
-   *         count was not requested and has not been initialized.
+   *         associated data source.
    */
-  @JsonInclude(NON_NULL)
-  Long getRecordCount();
+  long getRecordCount();
 
   /**
    * Sets the the total number of records that have been loaded for the 
@@ -59,15 +56,12 @@ public interface SzSourceCountStats {
 
   /**
    * Gets the total number of entities that have at least one record from
-   * the associated data source.  This returns <code>null</code> if the 
-   * entity count was not requested and has not been initialized.
+   * the associated data source.
    *
    * @return The total number of entities that have at least one record from
-   *         the associated data source, or <code>null</code> if the entity
-   *         count was not requested and has not been initialized.
+   *         the associated data source.
    */
-  @JsonInclude(NON_NULL)
-  Long getEntityCount();
+  long getEntityCount();
 
   /**
    * Sets total number of entities that have at least one record from
@@ -77,6 +71,29 @@ public interface SzSourceCountStats {
    *                    for the associated data source.
    */
   void setEntityCount(long entityCount);
+
+  /**
+   * Gets the total number of entities that have at least one record from
+   * the associated data source.  This value doubles as the number of
+   * entities having a record from the associated data source where that
+   * record is single <b>only</b> record in the entity.
+   *
+   * @return The total number of entities that have at least one record from
+   *         the associated data source.
+   */
+  long getUnmatchedRecordCount();
+
+  /**
+   * Sets total number of records that have been loaded for the associated 
+   * data source that did <b>not</b> match against any other record.  This
+   * value doubles as the number of entities having a record from the 
+   * associated data source where that record is single <b>only</b> record
+   * in the entity.
+   *
+   * @param entityCount The total number of entities that have been loaded
+   *                    for the associated data source.
+   */
+  void setUnmatchedRecordCount(long entityCount);
 
   /**
    * A {@link ModelProvider} for instances of {@link SzSourceCountStats}.

--- a/src/main/java/com/senzing/poc/model/SzSourceCountStats.java
+++ b/src/main/java/com/senzing/poc/model/SzSourceCountStats.java
@@ -1,0 +1,165 @@
+package com.senzing.poc.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.AbstractModelProvider;
+import com.senzing.api.model.ModelFactory;
+import com.senzing.api.model.ModelProvider;
+import com.senzing.poc.model.impl.SzSourceCountStatsImpl;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+/**
+ * Describes the count statistics for a specific data source.
+ */
+@JsonDeserialize(using = SzSourceCountStats.Factory.class)
+public interface SzSourceCountStats {
+  /**
+   * Gets the data source code identifying the data source to which the
+   * statistics are associated.
+   *
+   * @return The data source code identifying the data source to which the
+   *         statistics are associated.
+   */
+  String getDataSourceCode();
+
+  /**
+   * Sets the data source code identifying the data source to which the
+   * statistics are associated.
+   *
+   * @param dataSourceCode The non-null data source code identifying the data 
+   *                       source to which the statistics are associated.
+   * 
+   * @throws NullPointerException If the specified data source code is
+   *                              <code>null</code>.
+   */
+  void setDataSourceCode(String dataSourceCode)
+    throws NullPointerException;
+
+  /**
+   * Gets the total number of records that have been loaded for the 
+   * associated data source.  This returns <code>null</code> if the record
+   * count was not requested and has not been initialized.
+   *
+   * @return The total number of records that have been loaded for the 
+   *         associated data source, or <code>null</code> if the record
+   *         count was not requested and has not been initialized.
+   */
+  @JsonInclude(NON_NULL)
+  Long getRecordCount();
+
+  /**
+   * Sets the the total number of records that have been loaded for the 
+   * associated data source.
+   *
+   * @param recordCount The total number of records that have been loaded
+   *                    for the associated data source.
+   */
+  void setRecordCount(long recordCount);
+
+  /**
+   * Gets the total number of entities that have at least one record from
+   * the associated data source.  This returns <code>null</code> if the 
+   * entity count was not requested and has not been initialized.
+   *
+   * @return The total number of entities that have at least one record from
+   *         the associated data source, or <code>null</code> if the entity
+   *         count was not requested and has not been initialized.
+   */
+  @JsonInclude(NON_NULL)
+  Long getEntityCount();
+
+  /**
+   * Sets total number of entities that have at least one record from
+   * the associated data source.
+   *
+   * @param entityCount The total number of entities that have been loaded
+   *                    for the associated data source.
+   */
+  void setEntityCount(long entityCount);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzSourceCountStats}.
+   */
+  interface Provider extends ModelProvider<SzSourceCountStats> {
+    /**
+     * Creates a new instance of {@link SzSourceCountStats} with the
+     * specified data source code.
+     * 
+     * @param dataSourceCode The non-null data source code identifying the 
+     *                       data source to which the statistics are associated.
+     *
+     * @return The new instance of {@link SzSourceCountStats}
+     * 
+     * @throws NullPointerException If the specified data source code is 
+     *                              <code>null</code>.
+     */
+    SzSourceCountStats create(String dataSourceCode);
+  }
+
+  /**
+   * Provides a default {@link Provider} implementation for
+   * {@link SzSourceCountStats} that produces instances of
+   * {@link SzSourceCountStatsImpl}.
+   */
+  class DefaultProvider extends AbstractModelProvider<SzSourceCountStats>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzSourceCountStats.class, SzSourceCountStatsImpl.class);
+    }
+
+    @Override
+    public SzSourceCountStats create(String dataSourceCode) {
+      return new SzSourceCountStatsImpl(dataSourceCode);
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for {@link SzSourceCountStats}.
+   */
+  class Factory extends ModelFactory<SzSourceCountStats, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzSourceCountStats.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates a new instance of {@link SzSourceCountStats} with the
+     * specified data source code.
+     * 
+     * @param dataSourceCode The non-null data source code identifying the 
+     *                       data source to which the statistics are associated.
+     *
+     * @return The new instance of {@link SzSourceCountStats}
+     * 
+     * @throws NullPointerException If the specified data source code is 
+     *                              <code>null</code>.
+     */
+    public SzSourceCountStats create(String dataSourceCode)
+    {
+      return this.getProvider().create(dataSourceCode);
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/SzSourceCountStatsResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzSourceCountStatsResponse.java
@@ -4,7 +4,7 @@ import com.senzing.api.model.*;
 import com.senzing.poc.model.impl.SzSourceCountStatsResponseImpl;
 
 /**
- * Describes a response when queue info is requested.
+ * Describes a response when data source count statistics are requested.
  */
 public interface SzSourceCountStatsResponse extends SzBasicResponse {
   /**

--- a/src/main/java/com/senzing/poc/model/SzSourceCountStatsResponse.java
+++ b/src/main/java/com/senzing/poc/model/SzSourceCountStatsResponse.java
@@ -1,0 +1,143 @@
+package com.senzing.poc.model;
+
+import com.senzing.api.model.*;
+import com.senzing.poc.model.impl.SzSourceCountStatsResponseImpl;
+
+/**
+ * Describes a response when queue info is requested.
+ */
+public interface SzSourceCountStatsResponse extends SzBasicResponse {
+  /**
+   * Returns the {@link SzSourceCountStats} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  SzSourceCountStats getData();
+
+  /**
+   * Sets the data associated with this response with an {@link SzSourceCountStats}.
+   *
+   * @param info The {@link SzSourceCountStats} describing the statistics.
+   */
+  void setData(SzSourceCountStats info);
+
+  /**
+   * A {@link ModelProvider} for instances of {@link SzSourceCountStatsResponse}.
+   */
+  interface Provider extends ModelProvider<SzSourceCountStatsResponse> {
+    /**
+     * Constructs with only the {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    SzSourceCountStatsResponse create(SzMeta meta, SzLinks links);
+
+    /**
+     * Creates an instance with the specified {@liink SzMeta}, {@link SzLinks}
+     * and {@link SzSourceCountStats}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param countStats The {@link SzSourceCountStats} describing the data for this 
+     *                  instance.
+     */
+    SzSourceCountStatsResponse create(SzMeta              meta,
+                                      SzLinks             inks,
+                                      SzSourceCountStats  countStats);
+  }
+  
+  /**
+   * Provides a default {@link Provider} implementation for {@link
+   * SzSourceCountStatsResponse} that produces instances of
+   * {@link SzSourceCountStatsResponseImpl}.
+   */
+  class DefaultProvider 
+    extends AbstractModelProvider<SzSourceCountStatsResponse>
+    implements Provider
+  {
+    /**
+     * Default constructor.
+     */
+    public DefaultProvider() {
+      super(SzSourceCountStatsResponse.class,
+            SzSourceCountStatsResponseImpl.class);
+    }
+
+    @Override
+    public SzSourceCountStatsResponse create(SzMeta meta, SzLinks links){
+      return new SzSourceCountStatsResponseImpl(meta, links);
+    }
+
+    @Override
+    public SzSourceCountStatsResponse create(SzMeta             meta,
+                                             SzLinks            links,
+                                             SzSourceCountStats countStats)
+    {
+      return new SzSourceCountStatsResponseImpl(meta, links, countStats);
+    }
+  }
+
+  /**
+   * Provides a {@link ModelFactory} implementation for
+   * {@link SzSourceCountStatsResponse}.
+   */
+  class Factory extends ModelFactory<SzSourceCountStatsResponse, Provider> {
+    /**
+     * Default constructor.  This is public and can only be called after the
+     * singleton master instance is created as it inherits the same state from
+     * the master instance.
+     */
+    public Factory() {
+      super(SzSourceCountStatsResponse.class);
+    }
+
+    /**
+     * Constructs with the default provider.  This constructor is private and
+     * is used for the master singleton instance.
+     * @param defaultProvider The default provider.
+     */
+    private Factory(Provider defaultProvider) {
+      super(defaultProvider);
+    }
+
+    /**
+     * Creates an instance of {@link SzSourceCountStatsResponse} with the
+     * specified {@link SzMeta} and {@link SzLinks}.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     */
+    public SzSourceCountStatsResponse create(SzMeta meta, SzLinks links) {
+      return this.getProvider().create(meta, links);
+    }
+
+    /**
+     * Creates an instance of {@link SzSourceCountStatsResponse} with the
+     * specified {@link SzMeta}, {@link SzLinks} and the speicified {@link
+     * SzSourceCountStats} describing the bulk records.
+     *
+     * @param meta The response meta data.
+     *
+     * @param links The links for the response.
+     *
+     * @param CountStats The {@link SzSourceCountStats} describing the
+     *                     bulk records.
+     */
+    public SzSourceCountStatsResponse create(SzMeta             meta,
+                                             SzLinks            links,
+                                             SzSourceCountStats countStats)
+    {
+      return this.getProvider().create(meta, links, countStats);
+    }
+  }
+
+  /**
+   * The {@link Factory} instance for this interface.
+   */
+  Factory FACTORY = new Factory(new DefaultProvider());
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzCountStatsImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzCountStatsImpl.java
@@ -10,7 +10,7 @@ import com.senzing.poc.model.SzCountStats;
 import com.senzing.poc.model.SzSourceCountStats;
 
 /**
- * Provides a default implementation of {@link SzSourceCountStats}.
+ * Provides a default implementation of {@link SzCountStats}.
  */
 @JsonDeserialize
 public class SzCountStatsImpl implements SzCountStats {

--- a/src/main/java/com/senzing/poc/model/impl/SzCountStatsImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzCountStatsImpl.java
@@ -15,17 +15,22 @@ import com.senzing.poc.model.SzSourceCountStats;
 @JsonDeserialize
 public class SzCountStatsImpl implements SzCountStats {
   /**
-   * The total number of records loaded in the entity repository.  This
-   * is initialized to <code>null</code> if it has not yet been set.
+   * The total number of records loaded in the entity repository.
    */
-  private Long totalRecordCount = null;
+  private long totalRecordCount = 0L;
 
   /**
    * The total number of entities that have been resolved in the entity
-   * repository.  This is initialized to <code>null</code> if it has not
-   * yet been set.
+   * repository.
    */
-  private Long totalEntityCount = null;
+  private long totalEntityCount = 0L;
+
+  /**
+   * The total number of records loaded in the entity repository that
+   * failed to match against any other record.  This is also the number
+   * of entities in the repository that only have a single record.
+   */
+  private long totalUnmatchedRecordCount = 0L;
 
   /**
    * The {@link Map} of {@link String} data source code keys to {@link
@@ -38,13 +43,14 @@ public class SzCountStatsImpl implements SzCountStats {
    * Default constructor
    */
   public SzCountStatsImpl() {
-    this.totalRecordCount   = null;
-    this.totalEntityCount   = null;
-    this.dataSourceCounts   = new LinkedHashMap<>();
+    this.totalRecordCount           = 0L;
+    this.totalEntityCount           = 0L;
+    this.totalUnmatchedRecordCount  = 0L;
+    this.dataSourceCounts           = new LinkedHashMap<>();
   }
 
   @Override
-  public Long getTotalRecordCount() {
+  public long getTotalRecordCount() {
     return this.totalRecordCount;
   }
 
@@ -54,13 +60,23 @@ public class SzCountStatsImpl implements SzCountStats {
   }
 
   @Override
-  public Long getTotalEntityCount() {
+  public long getTotalEntityCount() {
     return this.totalEntityCount;
   }
 
   @Override
   public void setTotalEntityCount(long entityCount) {
     this.totalEntityCount = entityCount;
+  }
+
+  @Override
+  public long getTotalUnmatchedRecordCount() {
+    return this.totalUnmatchedRecordCount;
+  }
+
+  @Override
+  public void setTotalUnmatchedRecordCount(long recordCount) {
+    this.totalUnmatchedRecordCount = recordCount;
   }
 
   @Override

--- a/src/main/java/com/senzing/poc/model/impl/SzCountStatsImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzCountStatsImpl.java
@@ -1,0 +1,91 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.poc.model.SzCountStats;
+import com.senzing.poc.model.SzSourceCountStats;
+
+/**
+ * Provides a default implementation of {@link SzSourceCountStats}.
+ */
+@JsonDeserialize
+public class SzCountStatsImpl implements SzCountStats {
+  /**
+   * The total number of records loaded in the entity repository.  This
+   * is initialized to <code>null</code> if it has not yet been set.
+   */
+  private Long totalRecordCount = null;
+
+  /**
+   * The total number of entities that have been resolved in the entity
+   * repository.  This is initialized to <code>null</code> if it has not
+   * yet been set.
+   */
+  private Long totalEntityCount = null;
+
+  /**
+   * The {@link Map} of {@link String} data source code keys to {@link
+   * SzSourceCountStat} values describing the count statistics for that
+   * data source.
+   */
+  private Map<String, SzSourceCountStats> dataSourceCounts = null;
+
+  /**
+   * Default constructor
+   */
+  public SzCountStatsImpl() {
+    this.totalRecordCount   = null;
+    this.totalEntityCount   = null;
+    this.dataSourceCounts   = new LinkedHashMap<>();
+  }
+
+  @Override
+  public Long getTotalRecordCount() {
+    return this.totalRecordCount;
+  }
+
+  @Override
+  public void setTotalRecordCount(long recordCount) {
+    this.totalRecordCount = recordCount;
+  }
+
+  @Override
+  public Long getTotalEntityCount() {
+    return this.totalEntityCount;
+  }
+
+  @Override
+  public void setTotalEntityCount(long entityCount) {
+    this.totalEntityCount = entityCount;
+  }
+
+  @Override
+  public List<SzSourceCountStats> getDataSourceCounts() {
+    Collection<SzSourceCountStats> stats = this.dataSourceCounts.values();
+    return new ArrayList<>(stats);
+  }
+
+  @Override
+  public void setDataSourceCounts(List<SzSourceCountStats> statsList) {
+    this.dataSourceCounts.clear();
+    if (statsList != null) {
+        statsList.forEach( stats -> {
+            if (stats != null) {
+                this.dataSourceCounts.put(
+                    stats.getDataSourceCode(), stats);
+            }
+        });
+    }
+  }
+
+  @Override
+  public void addDataSourceCount(SzSourceCountStats stats) {
+    if (stats == null) return;
+    this.dataSourceCounts.put(stats.getDataSourceCode(), stats);
+  }
+
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzCountStatsResponseImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzCountStatsResponseImpl.java
@@ -1,0 +1,79 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.SzLinks;
+import com.senzing.api.model.SzMeta;
+import com.senzing.api.model.impl.SzBasicResponseImpl;
+import com.senzing.poc.model.SzCountStats;
+import com.senzing.poc.model.SzCountStatsResponse;
+
+/**
+ * Provides a default implementation of {@link SzCountStatsResponse}.
+ */
+@JsonDeserialize
+public class SzCountStatsResponseImpl extends SzBasicResponseImpl
+  implements SzCountStatsResponse
+{
+  /**
+   * The data for this instance.
+   */
+  private SzCountStats countStats;
+
+  /**
+   * Default constructor for JSON deserialization.
+   */
+  protected SzCountStatsResponseImpl() {
+    this.countStats = null;
+  }
+
+  /**
+   * Constructs with only the meta data and links, leaving the 
+   * count stats data to be initialized later.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   */
+  public SzCountStatsResponseImpl(SzMeta meta, SzLinks links) {
+    this(meta, links, null);
+  }
+
+  /**
+   * Constructs with the meta data, links, and the count stats data.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   * 
+   * @param countStats The {@link SzCountStats} describing the data
+   *                   for this instance.
+   */
+  public SzCountStatsResponseImpl(SzMeta        meta,
+                                  SzLinks       links,
+                                  SzCountStats  countStats)
+  {
+    super(meta, links);
+    Objects.requireNonNull(countStats, "The SzCountStats cannot be null");
+    this.countStats = countStats;
+  }
+
+  /**
+   * Returns the {@link SzCountStats} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  public SzCountStats getData() {
+    return this.countStats;
+  }
+
+  /**
+   * Sets the data associated with this response with an {@link SzCountStats}.
+   *
+   * @param countStats The {@link SzCountStats} describing the statistics.
+   */
+  public void setData(SzCountStats countStats) {
+    this.countStats = countStats;
+  }
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzEntitiesPageImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzEntitiesPageImpl.java
@@ -1,0 +1,157 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.poc.model.SzEntitiesPage;
+import com.senzing.poc.model.SzBoundType;
+
+/**
+ * Provides a default implementation of {@link SzEntitiesPage}.
+ */
+@JsonDeserialize
+public class SzEntitiesPageImpl implements SzEntitiesPage {
+  /**
+   * The entity ID bound value that bounds the included entity ID's.
+   */
+  private long bound = 0L;
+
+  /**
+   * The {@link SzBoundType} that describes how the bound value
+   * was applied.
+   */
+  private SzBoundType boundType = null;
+
+  /**
+   * The requested page size representing the maximum number of
+   * entity ID's that were requested to be returned.
+   */
+  private int pageSize = 0;
+
+  /**
+   * The total number of entities representing the set of all possible
+   * results across all pages.
+   */
+  private long totalEntityCount = 0L;
+
+  /**
+   * The number of entities in the set that exist on pages before this
+   * page.
+   */
+  private long beforeEntityCount = 0L;
+
+  /**
+   * The number of entities in the set that exist on pages after this
+   * page.
+   */
+  private long afterEntityCount = 0L;
+
+  /**
+   * The {@link Set} of {@link Long} entity ID's identifying the entities
+   * on this page.
+   */
+  private Set<Long> entityIds = null;
+
+  /**
+   * Default constructor
+   */
+  public SzEntitiesPageImpl() {
+    this.bound              = 0L;
+    this.boundType          = null;
+    this.pageSize           = 0;
+    this.totalEntityCount   = 0L;
+    this.beforeEntityCount  = 0L;
+    this.afterEntityCount   = 0L;
+    this.entityIds          = new HashSet<>();
+  }
+
+  @Override
+  public long getBound() {
+    return this.bound;
+  }
+
+  @Override
+  public void setBound(long bound) {
+    this.bound = bound;
+  }
+
+  @Override
+  public SzBoundType getBoundType() {
+    return this.boundType;
+  }
+
+  @Override
+  public void setBoundType(SzBoundType boundType) {
+    this.boundType = boundType;
+  }
+
+  @Override
+  public int getPageSize() {
+    return this.pageSize;
+  }
+
+  @Override
+  public void setPageSize(int pageSize) {
+    this.pageSize = pageSize;
+  }
+
+  @Override
+  public long getTotalEntityCount() {
+    return this.totalEntityCount;
+  }
+
+  @Override
+  public void setTotalEntityCount(long entityCount) {
+    this.totalEntityCount = entityCount;
+  }
+
+  @Override
+  public long getBeforeEntityCount() {
+    return this.beforeEntityCount;
+  }
+
+  @Override
+  public void setBeforeEntityCount(long entityCount) {
+    this.beforeEntityCount = entityCount;
+  }
+
+
+  @Override
+  public long getAfterEntityCount() {
+    return this.afterEntityCount;
+  }
+
+  @Override
+  public void setAfterEntityCount(long entityCount) {
+    this.afterEntityCount = entityCount;
+  }
+
+  @Override
+  public List<Long> getEntityIds() {
+    List<Long> ids = new ArrayList<>(this.entityIds);
+    ids.sort(null);
+    return ids;
+  }
+
+  @Override
+  public void setEntityIds(List<Long> entityIdList) {
+    this.entityIds.clear();
+    if (entityIdList != null) {
+      entityIdList.forEach( entityId -> {
+        if (entityId != null) {
+          this.entityIds.add(entityId);
+        }
+      });
+    }
+  }
+
+  @Override
+  public void addEntityId(long entityId) {
+    if (this.entityIds.contains(entityId)) return;
+    this.entityIds.add(entityId);
+  }
+
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzEntitiesPageResponseImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzEntitiesPageResponseImpl.java
@@ -1,0 +1,79 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.SzLinks;
+import com.senzing.api.model.SzMeta;
+import com.senzing.api.model.impl.SzBasicResponseImpl;
+import com.senzing.poc.model.SzEntitiesPage;
+import com.senzing.poc.model.SzEntitiesPageResponse;
+
+/**
+ * Provides a default implementation of {@link SzEntitiesPageResponse}.
+ */
+@JsonDeserialize
+public class SzEntitiesPageResponseImpl extends SzBasicResponseImpl
+  implements SzEntitiesPageResponse
+{
+  /**
+   * The data for this instance.
+   */
+  private SzEntitiesPage entitiesPage;
+
+  /**
+   * Default constructor for JSON deserialization.
+   */
+  protected SzEntitiesPageResponseImpl() {
+    this.entitiesPage = null;
+  }
+
+  /**
+   * Constructs with only the meta data and links, leaving the 
+   * count stats data to be initialized later.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   */
+  public SzEntitiesPageResponseImpl(SzMeta meta, SzLinks links) {
+    this(meta, links, null);
+  }
+
+  /**
+   * Constructs with the meta data, links, and the count stats data.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   * 
+   * @param EntitiesPage The {@link SzEntitiesPage} describing the data
+   *                   for this instance.
+   */
+  public SzEntitiesPageResponseImpl(SzMeta          meta,
+                                    SzLinks         links,
+                                    SzEntitiesPage  entitiesPage)
+  {
+    super(meta, links);
+    Objects.requireNonNull(entitiesPage, "The SzEntitiesPage cannot be null");
+    this.entitiesPage = entitiesPage;
+  }
+
+  /**
+   * Returns the {@link SzEntitiesPage} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  public SzEntitiesPage getData() {
+    return this.entitiesPage;
+  }
+
+  /**
+   * Sets the data associated with this response with an {@link SzEntitiesPage}.
+   *
+   * @param entitiesPage The {@link SzEntitiesPage} describing the statistics.
+   */
+  public void setData(SzEntitiesPage entitiesPage) {
+    this.entitiesPage = entitiesPage;
+  }
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzEntitySizeBreakdownImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzEntitySizeBreakdownImpl.java
@@ -1,0 +1,60 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.poc.model.SzEntitySizeBreakdown;
+import com.senzing.poc.model.SzEntitySizeCount;
+
+/**
+ * Provides a default implementation of {@link SzEntitySizeBreakdown}.
+ */
+@JsonDeserialize
+public class SzEntitySizeBreakdownImpl implements SzEntitySizeBreakdown {
+  /**
+   * The {@link Map} of {@link Integer} entity size keys to {@link
+   * SzEntitySizeCount} values describing the number of entities in
+   * the entity repository having that number of constituent records.
+   */
+  private Map<Integer, SzEntitySizeCount> entitySizeCounts = null;
+
+  /**
+   * Default constructor
+   */
+  public SzEntitySizeBreakdownImpl() {
+    this.entitySizeCounts = new LinkedHashMap<>();
+  }
+
+  @Override
+  public List<SzEntitySizeCount> getEntitySizeCounts() {
+    Collection<SzEntitySizeCount> sizeCounts = this.entitySizeCounts.values();
+    List<SzEntitySizeCount> result = new ArrayList<>(sizeCounts);
+    result.sort((c1, c2) -> {
+      return c2.getEntitySize() - c1.getEntitySize();
+    });
+    return result;
+  }
+
+  @Override
+  public void setEntitySizeCounts(List<SzEntitySizeCount> sizeCountList) {
+    this.entitySizeCounts.clear();
+    if (sizeCountList != null) {
+        sizeCountList.forEach( sizeCount -> {
+            if (sizeCount != null) {
+                this.entitySizeCounts.put(
+                    sizeCount.getEntitySize(), sizeCount);
+            }
+        });
+    }
+  }
+
+  @Override
+  public void addEntitySizeCount(SzEntitySizeCount sizeCount) {
+    if (sizeCount == null) return;
+    this.entitySizeCounts.put(sizeCount.getEntitySize(), sizeCount);
+  }
+
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzEntitySizeBreakdownResponseImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzEntitySizeBreakdownResponseImpl.java
@@ -1,0 +1,80 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.SzLinks;
+import com.senzing.api.model.SzMeta;
+import com.senzing.api.model.impl.SzBasicResponseImpl;
+import com.senzing.poc.model.SzEntitySizeBreakdown;
+import com.senzing.poc.model.SzEntitySizeBreakdownResponse;
+
+/**
+ * Provides a default implementation of {@link SzEntitySizeBreakdownResponse}.
+ */
+@JsonDeserialize
+public class SzEntitySizeBreakdownResponseImpl extends SzBasicResponseImpl
+  implements SzEntitySizeBreakdownResponse
+{
+  /**
+   * The data for this instance.
+   */
+  private SzEntitySizeBreakdown sizeBreakdown;
+
+  /**
+   * Default constructor for JSON deserialization.
+   */
+  protected SzEntitySizeBreakdownResponseImpl() {
+    this.sizeBreakdown = null;
+  }
+
+  /**
+   * Constructs with only the meta data and links, leaving the 
+   * count stats data to be initialized later.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   */
+  public SzEntitySizeBreakdownResponseImpl(SzMeta meta, SzLinks links) {
+    this(meta, links, null);
+  }
+
+  /**
+   * Constructs with the meta data, links, and the count stats data.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   * 
+   * @param EntitySizeBreakdown The {@link SzEntitySizeBreakdown} describing the data
+   *                   for this instance.
+   */
+  public SzEntitySizeBreakdownResponseImpl(
+    SzMeta                meta,
+    SzLinks               links,
+    SzEntitySizeBreakdown sizeBreakdown)
+  {
+    super(meta, links);
+    Objects.requireNonNull(sizeBreakdown, "The SzEntitySizeBreakdown cannot be null");
+    this.sizeBreakdown = sizeBreakdown;
+  }
+
+  /**
+   * Returns the {@link SzEntitySizeBreakdown} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  public SzEntitySizeBreakdown getData() {
+    return this.sizeBreakdown;
+  }
+
+  /**
+   * Sets the data associated with this response with an {@link SzEntitySizeBreakdown}.
+   *
+   * @param sizeBreakdown The {@link SzEntitySizeBreakdown} describing the statistics.
+   */
+  public void setData(SzEntitySizeBreakdown sizeBreakdown) {
+    this.sizeBreakdown = sizeBreakdown;
+  }
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzEntitySizeCountImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzEntitySizeCountImpl.java
@@ -1,0 +1,55 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.poc.model.SzEntitySizeCount;
+import com.senzing.poc.model.SzSourceCountStats;
+
+/**
+ * Provides a default implementation of {@link SzEntitySizeCount}.
+ */
+@JsonDeserialize
+public class SzEntitySizeCountImpl implements SzEntitySizeCount {
+  /**
+   * The entity size described by the number of records in the entities.
+   */
+  private int entitySize = 0;
+
+  /**
+   * The number of entities having an entity size equal to the associated
+   * record count.
+   */
+  private long entityCount = 0L;
+
+  /**
+   * Default constructor
+   */
+  public SzEntitySizeCountImpl() {
+    this.entitySize   = 0;
+    this.entityCount  = 0L;
+  }
+
+  @Override
+  public int getEntitySize() {
+    return this.entitySize;
+  }
+
+  @Override
+  public void setEntitySize(int recordCount) {
+    this.entitySize = recordCount;
+  }
+
+  @Override
+  public long getEntityCount() {
+    return this.entityCount;
+  }
+
+  @Override
+  public void setEntityCount(long entityCount) {
+    this.entityCount = entityCount;
+  }
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzEntitySizeCountResponseImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzEntitySizeCountResponseImpl.java
@@ -1,0 +1,80 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.SzLinks;
+import com.senzing.api.model.SzMeta;
+import com.senzing.api.model.impl.SzBasicResponseImpl;
+import com.senzing.poc.model.SzEntitySizeCount;
+import com.senzing.poc.model.SzEntitySizeCountResponse;
+
+/**
+ * Provides a default implementation of {@link SzEntitySizeCountResponse}.
+ */
+@JsonDeserialize
+public class SzEntitySizeCountResponseImpl extends SzBasicResponseImpl
+  implements SzEntitySizeCountResponse
+{
+  /**
+   * The data for this instance.
+   */
+  private SzEntitySizeCount sizeCount;
+
+  /**
+   * Default constructor for JSON deserialization.
+   */
+  protected SzEntitySizeCountResponseImpl() {
+    this.sizeCount = null;
+  }
+
+  /**
+   * Constructs with only the meta data and links, leaving the 
+   * count stats data to be initialized later.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   */
+  public SzEntitySizeCountResponseImpl(SzMeta meta, SzLinks links) {
+    this(meta, links, null);
+  }
+
+  /**
+   * Constructs with the meta data, links, and the count stats data.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   * 
+   * @param EntitySizeCount The {@link SzEntitySizeCount} describing the data
+   *                   for this instance.
+   */
+  public SzEntitySizeCountResponseImpl(
+    SzMeta                meta,
+    SzLinks               links,
+    SzEntitySizeCount sizeCount)
+  {
+    super(meta, links);
+    Objects.requireNonNull(sizeCount, "The SzEntitySizeCount cannot be null");
+    this.sizeCount = sizeCount;
+  }
+
+  /**
+   * Returns the {@link SzEntitySizeCount} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  public SzEntitySizeCount getData() {
+    return this.sizeCount;
+  }
+
+  /**
+   * Sets the data associated with this response with an {@link SzEntitySizeCount}.
+   *
+   * @param sizeCount The {@link SzEntitySizeCount} describing the statistics.
+   */
+  public void setData(SzEntitySizeCount sizeCount) {
+    this.sizeCount = sizeCount;
+  }
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzQueueInfoResponseImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzQueueInfoResponseImpl.java
@@ -39,8 +39,7 @@ public class SzQueueInfoResponseImpl extends SzBasicResponseImpl
   }
 
   /**
-   * Constructs with only the meta data and links, leaving the queue info
-   * data to be initialized later.
+   * Constructs with only the meta data, links, and the queue info data.
    *
    * @param meta The response meta data.
    *
@@ -69,7 +68,7 @@ public class SzQueueInfoResponseImpl extends SzBasicResponseImpl
   /**
    * Sets the data associated with this response with an {@link SzQueueInfo}.
    *
-   * @param info The {@link SzQueueInfo} describing the license.
+   * @param info The {@link SzQueueInfo} describing the queue.
    */
   public void setData(SzQueueInfo info) {
     this.queueInfo = info;

--- a/src/main/java/com/senzing/poc/model/impl/SzSourceCountStatsImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzSourceCountStatsImpl.java
@@ -16,17 +16,21 @@ public class SzSourceCountStatsImpl implements SzSourceCountStats {
   private String dataSourceCode;
 
   /**
-   * The number of records loaded for the data source.  This is initialized
-   * to <code>null</code> if it has not yet been set.
+   * The number of records loaded for the data source.
    */
-  private Long recordCount = null;
+  private long recordCount = 0L;
 
   /**
    * The number of entities having at least one record from the associated
-   * data source.  This is initialized
-   * to <code>null</code> if it has not yet been set.
+   * data source.
    */
-  private Long entityCount = null;
+  private long entityCount = 0L;
+
+  /**
+   * The number of records loaded for the data source that failed to
+   * match against any other record in the repository.
+   */
+  private long unmatchedRecordCount = 0L;
 
   /**
    * Constructs with the specified data source code.
@@ -42,8 +46,9 @@ public class SzSourceCountStatsImpl implements SzSourceCountStats {
   {
     Objects.requireNonNull(dataSourceCode, "Data source code cannot be null");
     this.dataSourceCode = dataSourceCode;
-    this.recordCount    = null;
-    this.entityCount    = null;
+    this.recordCount          = 0L;
+    this.entityCount          = 0L;
+    this.unmatchedRecordCount = 0L;
   }
 
   @Override
@@ -57,7 +62,7 @@ public class SzSourceCountStatsImpl implements SzSourceCountStats {
   }
 
   @Override
-  public Long getRecordCount() {
+  public long getRecordCount() {
     return this.recordCount;
   }
 
@@ -67,12 +72,22 @@ public class SzSourceCountStatsImpl implements SzSourceCountStats {
   }
 
   @Override
-  public Long getEntityCount() {
+  public long getEntityCount() {
     return this.entityCount;
   }
 
   @Override
   public void setEntityCount(long entityCount) {
     this.entityCount = entityCount;
+  }
+
+  @Override
+  public long getUnmatchedRecordCount() {
+    return this.unmatchedRecordCount;
+  }
+
+  @Override
+  public void setUnmatchedRecordCount(long recordCount) {
+    this.unmatchedRecordCount = recordCount;
   }
 }

--- a/src/main/java/com/senzing/poc/model/impl/SzSourceCountStatsImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzSourceCountStatsImpl.java
@@ -1,0 +1,78 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.poc.model.SzSourceCountStats;
+
+/**
+ * Provides a default implementation of {@link SzSourceCountsStats}.
+ */
+@JsonDeserialize
+public class SzSourceCountStatsImpl implements SzSourceCountStats {
+  /**
+   * The data source code 
+   */
+  private String dataSourceCode;
+
+  /**
+   * The number of records loaded for the data source.  This is initialized
+   * to <code>null</code> if it has not yet been set.
+   */
+  private Long recordCount = null;
+
+  /**
+   * The number of entities having at least one record from the associated
+   * data source.  This is initialized
+   * to <code>null</code> if it has not yet been set.
+   */
+  private Long entityCount = null;
+
+  /**
+   * Constructs with the specified data source code.
+   * 
+   * @param dataSourceCode The data source code identifying the data source to
+   *                       which the statistics pertain.
+   * 
+   * @throws NullPointerException If the specified data source code is
+   *                              <code>null</code>.
+   */
+  public SzSourceCountStatsImpl(String dataSourceCode) 
+    throws NullPointerException
+  {
+    Objects.requireNonNull(dataSourceCode, "Data source code cannot be null");
+    this.dataSourceCode = dataSourceCode;
+    this.recordCount    = null;
+    this.entityCount    = null;
+  }
+
+  @Override
+  public String getDataSourceCode() {
+    return this.dataSourceCode;
+  }
+
+  @Override
+  public void setDataSourceCode(String dataSourceCode) {
+    this.dataSourceCode = dataSourceCode;
+  }
+
+  @Override
+  public Long getRecordCount() {
+    return this.recordCount;
+  }
+
+  @Override
+  public void setRecordCount(long recordCount) {
+    this.recordCount = recordCount;
+  }
+
+  @Override
+  public Long getEntityCount() {
+    return this.entityCount;
+  }
+
+  @Override
+  public void setEntityCount(long entityCount) {
+    this.entityCount = entityCount;
+  }
+}

--- a/src/main/java/com/senzing/poc/model/impl/SzSourceCountStatsResponseImpl.java
+++ b/src/main/java/com/senzing/poc/model/impl/SzSourceCountStatsResponseImpl.java
@@ -1,0 +1,79 @@
+package com.senzing.poc.model.impl;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.senzing.api.model.SzLinks;
+import com.senzing.api.model.SzMeta;
+import com.senzing.api.model.impl.SzBasicResponseImpl;
+import com.senzing.poc.model.SzSourceCountStats;
+import com.senzing.poc.model.SzSourceCountStatsResponse;
+
+/**
+ * Provides a default implementation of {@link SzSourceCountStatsResponse}.
+ */
+@JsonDeserialize
+public class SzSourceCountStatsResponseImpl extends SzBasicResponseImpl
+  implements SzSourceCountStatsResponse
+{
+  /**
+   * The data for this instance.
+   */
+  private SzSourceCountStats countStats;
+
+  /**
+   * Default constructor for JSON deserialization.
+   */
+  protected SzSourceCountStatsResponseImpl() {
+    this.countStats = null;
+  }
+
+  /**
+   * Constructs with only the meta data and links, leaving the 
+   * count stats data to be initialized later.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   */
+  public SzSourceCountStatsResponseImpl(SzMeta meta, SzLinks links) {
+    this(meta, links, null);
+  }
+
+  /**
+   * Constructs with the meta data, links, and the count stats data.
+   *
+   * @param meta The response meta data.
+   *
+   * @param links The links for the response.
+   * 
+   * @param countStats The {@link SzSourceCountStats} describing the data
+   *                   for this instance.
+   */
+  public SzSourceCountStatsResponseImpl(SzMeta        meta,
+                                  SzLinks       links,
+                                  SzSourceCountStats  countStats)
+  {
+    super(meta, links);
+    Objects.requireNonNull(countStats, "The SzSourceCountStats cannot be null");
+    this.countStats = countStats;
+  }
+
+  /**
+   * Returns the {@link SzSourceCountStats} associated with this response.
+   *
+   * @return The data associated with this response.
+   */
+  public SzSourceCountStats getData() {
+    return this.countStats;
+  }
+
+  /**
+   * Sets the data associated with this response with an {@link SzSourceCountStats}.
+   *
+   * @param countStats The {@link SzSourceCountStats} describing the statistics.
+   */
+  public void setData(SzSourceCountStats countStats) {
+    this.countStats = countStats;
+  }
+}

--- a/src/main/java/com/senzing/poc/server/SzDataMartMessageSink.java
+++ b/src/main/java/com/senzing/poc/server/SzDataMartMessageSink.java
@@ -1,0 +1,129 @@
+package com.senzing.poc.server;
+
+import java.sql.SQLException;
+
+import com.senzing.api.services.SzMessageSink;
+import com.senzing.api.services.SzMessage;
+
+import static com.senzing.listener.communication.sql.SQLConsumer.MessageQueue;
+import static com.senzing.util.LoggingUtilities.*;
+
+/**
+ * Provides an {@link SzMessageSink} that will always enqueue INFO messages
+ * on the embedded data mart's database message queue <b>and</b> may optionally
+ * also forward those messages to a message queue configured in the startup
+ * parameters of the {@link SzPocServer}.
+ */
+public class SzDataMartMessageSink implements SzMessageSink {
+    /**
+     * The message sink provider type for the data mart.
+     */  
+    public static final String DATA_MART_PROVIDER_TYPE = "Data Mart Database Queue";
+
+    /**
+     * The backing message sink.
+     */
+    private SzMessageSink backingSink = null;
+
+    /**
+     * The backing {@link MessageQueue}.
+     */
+    private MessageQueue messageQueue = null;
+
+    /**
+     * Constructs with the specified message queue
+     */
+    public SzDataMartMessageSink(MessageQueue   messageQueue,
+                                 SzMessageSink  messageSink)
+    {
+        this.backingSink    = messageSink;
+        this.messageQueue   = messageQueue;
+    }
+
+    /**
+     * Package-protected method for obtaining the backing sink to use for releasing
+     * the acquired sink.  This returns <code>null</code> if none.
+     * 
+     * @return The backing sink to use for releasing the acquired sink, or
+     *         <code>null</code> if none.
+     */
+    SzMessageSink getBackingSink() {
+        return this.backingSink;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Overridden to also enqueue the message to the backing message queue in 
+     * addition to any backing {@link SzMessageSink} (if one exists).
+     */
+    @Override
+    public void send(SzMessage message, FailureHandler onFailure)
+        throws Exception
+    {
+        Exception failure = null;
+        try {
+            this.messageQueue.enqueueMessage(message.getBody());
+        } catch (SQLException e) {
+            onFailure.handle(e, message);
+            failure = e;
+        }
+        if (this.backingSink != null) {
+            try {
+                this.backingSink.send(message, onFailure);
+            } catch (Exception e) {
+                failure = e;
+            }
+        }
+        if (failure != null) throw failure;
+    }
+
+   /**
+    * {@inheritDoc}
+    * <p>
+    * Overridden to return the provider type from the backing message sink if one
+    * exists, otherwise this returns {@link #DATA_MART_PROVIDER_TYPE}.
+    */
+    @Override
+    public String getProviderType() {
+        if (this.backingSink == null) {
+            return "Data Mart Database Queue";
+        } else {
+            return this.backingSink.getProviderType();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Overridden to return the message count from the backing message sink if one
+     * exists, otherwise this returns the result from {@link 
+     * MessageQueue#getMessageCount()}.
+     */
+    @Override
+    public Integer getMessageCount() {
+        if (this.backingSink == null) {
+            try {
+                return this.messageQueue.getMessageCount();
+            } catch (SQLException e) {
+                logWarning(e, "Failed to get message count from SQL message queue");
+                return null;
+            }
+
+        } else {
+            return this.backingSink.getMessageCount();
+        }
+    }
+
+    /**
+     * Checks if this instance has a backing sync whereby it will also 
+     * send the INFO messages to a message queue in addition to the database
+     * messge queue.
+     * 
+     * @return <code>true</code> if this instance has a backing sync and 
+     *         <code>false</code> if it does not.
+     */
+    public boolean hasBackingSync() {
+        return (this.backingSink != null);
+    }
+}

--- a/src/main/java/com/senzing/poc/server/SzPocProvider.java
+++ b/src/main/java/com/senzing/poc/server/SzPocProvider.java
@@ -1,9 +1,34 @@
 package com.senzing.poc.server;
 
 import com.senzing.api.services.SzApiProvider;
+import com.senzing.datamart.SzReplicationProvider;
 import com.senzing.api.services.SzMessageSink;
 
+/**
+ * The {@link SzPocProvider} used by the service operations to
+ * interact with the server context.
+ */
 public interface SzPocProvider extends SzApiProvider {
+  /**
+   * Checks if this instance has a configured {@link SzMessageSink} for handling
+   * INFO messages in addition to the default sql-based data mart INFO message sync
+   * that all POC server's have for handling INFO messages via its embedded data 
+   * mart replicator.
+   * 
+   * @return <code>true</code> if there is an actual {@link SzMessageSink} configured
+   *         in addition to data mart message queue, otherwise <code>false</code>
+   */
+  boolean hasConfiguredInfoSink();
+
+  /**
+   * Return the {@link SzReplicationProvider} to use for interacting with the data
+   * mart replicator context.
+   * 
+   * @return The {@link SzReplicationProvider} to use for interacting with the 
+   *         data mart replicator context.
+   */
+  SzReplicationProvider getReplicationProvider();
+  
   /**
    * Checks if there is a load message sink configured for asynchronous loading.
    *

--- a/src/main/java/com/senzing/poc/server/SzPocServerOption.java
+++ b/src/main/java/com/senzing/poc/server/SzPocServerOption.java
@@ -1,10 +1,12 @@
 package com.senzing.poc.server;
 
 import java.util.*;
+import java.io.File;
 
 import com.senzing.api.server.SzApiServerOption;
 import com.senzing.cmdline.*;
 
+import static com.senzing.api.server.SzApiServerOption.*;
 import static com.senzing.util.CollectionUtilities.recursivelyUnmodifiableMap;
 import static com.senzing.api.server.mq.KafkaEndpoint.*;
 import static com.senzing.api.server.mq.SqsEndpoint.*;
@@ -36,7 +38,8 @@ public enum SzPocServerOption
   SQS_LOAD_URL(
       "--sqs-load-url", Set.of("-sqsLoadUrl"),
       "SENZING_SQS_LOAD_QUEUE_URL",
-      List.of("SENZING_SQS_QUEUE_URL"), 1,
+      List.of("SENZING_SQS_QUEUE_URL"), 
+      false, 1, true,
       SQS_LOAD_QUEUE_GROUP, URL_PROPERTY_KEY, false),
 
   /**
@@ -60,7 +63,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_USER(
       "--rabbit-load-user", Set.of("-rabbitLoadUser"),
       "SENZING_RABBITMQ_LOAD_USERNAME",
-      List.of("SENZING_RABBITMQ_USERNAME"), 1,
+      List.of("SENZING_RABBITMQ_USERNAME"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, USER_PROPERTY_KEY, false),
 
   /**
@@ -84,7 +88,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_PASSWORD(
       "--rabbit-load-password", Set.of("-rabbitLoadPassword"),
       "SENZING_RABBITMQ_LOAD_PASSWORD",
-      List.of("SENZING_RABBITMQ_PASSWORD"), 1,
+      List.of("SENZING_RABBITMQ_PASSWORD"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, PASSWORD_PROPERTY_KEY, false),
 
   /**
@@ -108,7 +113,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_HOST(
       "--rabbit-load-host", Set.of("-rabbitLoadHost"),
       "SENZING_RABBITMQ_LOAD_HOST",
-      List.of("SENZING_RABBITMQ_HOST"), 1,
+      List.of("SENZING_RABBITMQ_HOST"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, HOST_PROPERTY_KEY, false),
 
   /**
@@ -132,7 +138,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_PORT(
       "--rabbit-load-port", Set.of("-rabbitLoadPort"),
       "SENZING_RABBITMQ_LOAD_PORT",
-      List.of("SENZING_RABBITMQ_PORT"), 1,
+      List.of("SENZING_RABBITMQ_PORT"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, PORT_PROPERTY_KEY, false),
 
   /**
@@ -156,7 +163,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_VIRTUAL_HOST(
       "--rabbit-load-virtual-host", Set.of("-rabbitLoadVirtualHost"),
       "SENZING_RABBITMQ_LOAD_VIRTUAL_HOST",
-      List.of("SENZING_RABBITMQ_VIRTUAL_HOST"), 1,
+      List.of("SENZING_RABBITMQ_VIRTUAL_HOST"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, VIRTUAL_HOST_PROPERTY_KEY, false),
 
   /**
@@ -180,7 +188,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_EXCHANGE(
       "--rabbit-load-exchange", Set.of("-rabbitLoadExchange"),
       "SENZING_RABBITMQ_LOAD_EXCHANGE",
-      List.of("SENZING_RABBITMQ_EXCHANGE"), 1,
+      List.of("SENZING_RABBITMQ_EXCHANGE"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, EXCHANGE_PROPERTY_KEY, false),
 
   /**
@@ -203,7 +212,8 @@ public enum SzPocServerOption
   RABBIT_LOAD_ROUTING_KEY(
       "--rabbit-load-routing-key", Set.of("-rabbitLoadRoutingKey"),
       "SENZING_RABBITMQ_LOAD_ROUTING_KEY",
-      List.of("SENZING_RABBITMQ_ROUTING_KEY"), 1,
+      List.of("SENZING_RABBITMQ_ROUTING_KEY"),
+      false, 1, true,
       RABBITMQ_LOAD_QUEUE_GROUP, ROUTING_KEY_PROPERTY_KEY, false),
 
   /**
@@ -229,7 +239,8 @@ public enum SzPocServerOption
   KAFKA_LOAD_BOOTSTRAP_SERVER(
       "--kafka-load-bootstrap-server", Set.of("-kafkaLoadBootstrapServer"),
       "SENZING_KAFKA_LOAD_BOOTSTRAP_SERVER",
-      List.of("SENZING_KAFKA_BOOTSTRAP_SERVER"), 1,
+      List.of("SENZING_KAFKA_BOOTSTRAP_SERVER"),
+      false, 1, true,
       KAFKA_LOAD_QUEUE_GROUP, BOOTSTRAP_SERVERS_PROPERTY_KEY, false),
 
   /**
@@ -254,8 +265,9 @@ public enum SzPocServerOption
   KAFKA_LOAD_GROUP(
       "--kafka-load-group", Set.of("-kafkaLoadGroup"),
       "SENZING_KAFKA_LOAD_GROUP",
-      List.of("SENZING_KAFKA_GROUP"), 1, KAFKA_LOAD_QUEUE_GROUP,
-      GROUP_ID_PROPERTY_KEY, true),
+      List.of("SENZING_KAFKA_GROUP"),
+      false, 1, true,
+      KAFKA_LOAD_QUEUE_GROUP, GROUP_ID_PROPERTY_KEY, true),
 
   /**
    * <p>
@@ -277,8 +289,159 @@ public enum SzPocServerOption
   KAFKA_LOAD_TOPIC(
       "--kafka-load-topic", Set.of("-kafkaLoadTopic"),
       "SENZING_KAFKA_LOAD_TOPIC",
-      List.of("SENZING_KAFKA_TOPIC"), 1,
-      KAFKA_LOAD_QUEUE_GROUP, TOPIC_PROPERTY_KEY, false);
+      List.of("SENZING_KAFKA_TOPIC"),
+      false, 1, true,
+      KAFKA_LOAD_QUEUE_GROUP, TOPIC_PROPERTY_KEY, false),
+
+  /**
+   * <p>
+   * This option is used to specify the SQLite database file to connect to for
+   * the data mart.  The single parameter to this option is the file path to
+   * the SQLite database file to use.  If this option is specified the database
+   * options for other database types cannot be specified.
+   * <p>
+   * This option can be specified in the following ways:
+   * <ul>
+   *   <li>Command Line: <code>--sqlite-database-file {file-path}</code></li>
+   *   <li>Environment: <code>SENZING_REPLICATOR_SQLITE_DATABASE_FILE="{file-path}"</code></li>
+   * </ul>
+   */
+  SQLITE_DATABASE_FILE(
+      "--sqlite-database-file",
+      Set.of("-sqliteDatabaseFile"),
+      "SENZING_DATA_MART_SQLITE_DATABASE_FILE",
+      null, 1),
+
+  /**
+   * <p>
+   * This option is used to specify the PostgreSQL database server host to
+   * connect to for the data mart.  The single parameter to this option is
+   * server host name or IP address for the PostgreSQL database server.  If
+   * this option is specified the database options for other database types
+   * (e.g.: {@link #SQLITE_DATABASE_FILE}) cannot be specified and the other
+   * PostgreSQL options (e.g.: {@link #POSTGRESQL_PORT}) are required.
+   * <p>
+   * This option can be specified in the following ways:
+   * <ul>
+   *   <li>Command Line: <code>--postgresql-host {host-name|ip-address}</code></li>
+   *   <li>Environment: <code>SENZING_REPLICATOR_POSTGRESQL_HOST="{host-name|ip-address}"</code></li>
+   * </ul>
+   *
+   * @see #POSTGRESQL_PORT
+   * @see #POSTGRESQL_DATABASE
+   * @see #POSTGRESQL_USER
+   * @see #POSTGRESQL_PORT
+   */
+  POSTGRESQL_HOST(
+      "--postgresql-host",
+      Set.of("-postgresqlHost"),
+      "SENZING_DATA_MART_POSTGRESQL_HOST",
+      null, 1),
+
+  /**
+   * <p>
+   * This option is used to specify the PostgreSQL database server port to
+   * connect to for the data mart.  The single parameter to this option is the
+   * port number for the PostgreSQL database server.  If this option is
+   * specified the database options for other database types (e.g.: {@link
+   * #SQLITE_DATABASE_FILE}) cannot be specified and the other PostgreSQL
+   * options (e.g.: {@link #POSTGRESQL_PORT}) are required.
+   * <p>
+   * This option can be specified in the following ways:
+   * <ul>
+   *   <li>Command Line: <code>--postgresql-port {port-number}</code></li>
+   *   <li>Environment: <code>SENZING_REPLICATOR_POSTGRESQL_PORT="{port-number}"</code></li>
+   * </ul>
+   *
+   * @see #POSTGRESQL_HOST
+   * @see #POSTGRESQL_DATABASE
+   * @see #POSTGRESQL_USER
+   * @see #POSTGRESQL_PORT
+   */
+  POSTGRESQL_PORT(
+      "--postgresql-port",
+      Set.of("-postgresqlPort"),
+      "SENZING_DATA_MART_POSTGRESQL_PORT",
+      null, 1),
+
+  /**
+   * <p>
+   * This option is used to specify the PostgreSQL database name for the data
+   * mart.  The single parameter to this option is the PostgreSQL database name
+   * for the data mart.  If this option is specified the database options for
+   * other database types (e.g.: {@link #SQLITE_DATABASE_FILE}) cannot be
+   * specified and the other PostgreSQL options (e.g.: {@link
+   * #POSTGRESQL_HOST}) are required.
+   * <p>
+   * This option can be specified in the following ways:
+   * <ul>
+   *   <li>Command Line: <code>--postgresql-database {database-name}</code></li>
+   *   <li>Environment: <code>SENZING_REPLICATOR_POSTGRESQL_DATABASE="{database-name}"</code></li>
+   * </ul>
+   *
+   * @see #POSTGRESQL_HOST
+   * @see #POSTGRESQL_PORT
+   * @see #POSTGRESQL_USER
+   * @see #POSTGRESQL_PORT
+   *
+   */
+  POSTGRESQL_DATABASE(
+      "--postgresql-database",
+      Set.of("-postgresqlDatabase"),
+      "SENZING_DATA_MART_POSTGRESQL_DATABASE",
+      null, 1),
+
+  /**
+   * <p>
+   * This option is used to specify the PostgreSQL database user name to login
+   * to the PostgreSQL database server for the data mart.  The single parameter
+   * to this option is the user name for the PostgreSQL database server.  If
+   * this option is specified the database options for other database types
+   * (e.g.: {@link #SQLITE_DATABASE_FILE}) cannot be specified and the other
+   * PostgreSQL options (e.g.: {@link #POSTGRESQL_HOST}) are required.
+   * <p>
+   * This option can be specified in the following ways:
+   * <ul>
+   *   <li>Command Line: <code>--postgresql-user {user-name}</code></li>
+   *   <li>Environment: <code>SENZING_REPLICATOR_POSTGRESQL_USER="{user-name}"</code></li>
+   * </ul>
+   *
+   * @see #POSTGRESQL_HOST
+   * @see #POSTGRESQL_PORT
+   * @see #POSTGRESQL_DATABASE
+   * @see #POSTGRESQL_PORT
+   */
+  POSTGRESQL_USER(
+      "--postgresql-user",
+      Set.of("-postgresqlUser"),
+      "SENZING_DATA_MART_POSTGRESQL_USER",
+      null, 1),
+
+  /**
+   * <p>
+   * This option is used to specify the PostgreSQL database user password to
+   * login to the PostgreSQL database server for the data mart.  The single
+   * parameter to this option is the password for the PostgreSQL database user.
+   * If this option is specified the database options for other database types
+   * (e.g.: {@link #SQLITE_DATABASE_FILE}) cannot be specified and the other
+   * PostgreSQL options (e.g.: {@link #POSTGRESQL_HOST}) are required.
+   * <p>
+   * This option can be specified in the following ways:
+   * <ul>
+   *   <li>Command Line: <code>--postgresql-password {password}</code></li>
+   *   <li>Environment: <code>SENZING_REPLICATOR_POSTGRESQL_PASSWORD="{password}"</code></li>
+   * </ul>
+   *
+   * @see #POSTGRESQL_HOST
+   * @see #POSTGRESQL_PORT
+   * @see #POSTGRESQL_DATABASE
+   * @see #POSTGRESQL_USER
+   */
+  POSTGRESQL_PASSWORD(
+      "--postgresql-password",
+      Set.of("-postgresqlPassword"),
+      "SENZING_DATA_MART_POSTGRESQL_PASSWORD",
+      null, 1);
 
   /**
    * The {@link Map} of {@link SzPocServerOption} keys to unmodifiable
@@ -381,7 +544,7 @@ public enum SzPocServerOption
          null,
          true);
   }
-
+  
   SzPocServerOption(String        cmdLineFlag,
                     Set<String>   synonymFlags,
                     String        envVariable,
@@ -774,11 +937,14 @@ public enum SzPocServerOption
 
   static {
     try {
+      Map<SzPocServerOption, Set<Set<CommandLineOption>>> dependencyMap
+          = new LinkedHashMap<>();
       Map<SzPocServerOption,Set<CommandLineOption>> conflictMap = new LinkedHashMap<>();
       Map<SzPocServerOption,Set<SzPocServerOption>> altMap = new LinkedHashMap<>();
       Map<String, SzPocServerOption> lookupMap = new LinkedHashMap<>();
 
       for (SzPocServerOption option : SzPocServerOption.values()) {
+        dependencyMap.put(option, new LinkedHashSet<>());
         conflictMap.put(option, new LinkedHashSet<>());
         altMap.put(option, new LinkedHashSet<>());
         lookupMap.put(option.getCommandLineFlag().toLowerCase(), option);
@@ -839,8 +1005,55 @@ public enum SzPocServerOption
         conflicts.add(SzApiServerOption.READ_ONLY);
       }
 
-      Map<SzPocServerOption, Set<Set<CommandLineOption>>> dependencyMap
-          = new LinkedHashMap<>();
+      // create a set of SQLite options
+      Set<CommandLineOption> sqliteOptions = Set.of(SQLITE_DATABASE_FILE);
+
+      // create the set of PostgreSQL options
+      Set<CommandLineOption> postgreSqlOptions = Set.of(POSTGRESQL_HOST,
+                                                        POSTGRESQL_PORT,
+                                                        POSTGRESQL_DATABASE,
+                                                        POSTGRESQL_USER,
+                                                        POSTGRESQL_PASSWORD);
+
+      Set<CommandLineOption> requiredPostgreSQL = Set.of(POSTGRESQL_HOST,
+                                                         POSTGRESQL_DATABASE,
+                                                         POSTGRESQL_USER,
+                                                         POSTGRESQL_PASSWORD);
+
+      // setup dependencies and conflicts for the PostgreSQL options
+      for (CommandLineOption option: postgreSqlOptions) {
+        // get the set of dependency sets
+        Set<Set<CommandLineOption>> dependencySets = dependencyMap.get(option);
+
+        // create a new set
+        Set<CommandLineOption> dependSet = new LinkedHashSet<>();
+
+        // add all required PostgreSQL options to the set
+        dependSet.addAll(requiredPostgreSQL);
+
+        // remove the current option
+        dependSet.remove(option);
+
+        // add the dependency set
+        if (dependSet.size() > 0) {
+          dependencySets.add(Collections.unmodifiableSet(dependSet));
+        }
+
+        // now set the conflicts
+        conflictMap.put((SzPocServerOption) option, sqliteOptions);
+      }
+
+      // setup conflicts for the database options
+      conflictMap.put(SQLITE_DATABASE_FILE, postgreSqlOptions);
+
+      List<Set<CommandLineOption>> baseDependSets = new LinkedList<>();
+      Set<CommandLineOption> dependSet = new LinkedHashSet<>();
+      dependSet.add(SQLITE_DATABASE_FILE);
+      baseDependSets.add(Collections.unmodifiableSet(dependSet));
+
+      dependSet = new LinkedHashSet<>();
+      dependSet.addAll(requiredPostgreSQL);
+      baseDependSets.add(Collections.unmodifiableSet(dependSet));
 
       // handle dependencies for groups of options that go together
       Map<String, Set<SzPocServerOption>> groups = new LinkedHashMap<>();
@@ -930,16 +1143,24 @@ public enum SzPocServerOption
         case RABBIT_LOAD_EXCHANGE:
         case RABBIT_LOAD_ROUTING_KEY:
         case SQS_LOAD_URL:
+        case POSTGRESQL_HOST:
+        case POSTGRESQL_DATABASE:
+        case POSTGRESQL_USER:
+        case POSTGRESQL_PASSWORD:
           return params.get(0);
 
+        case POSTGRESQL_PORT:
         case RABBIT_LOAD_PORT: {
           int port = Integer.parseInt(params.get(0));
           if (port < 0) {
             throw new IllegalArgumentException(
-                "Negative RabbitMQ port numbers are not allowed: " + port);
+                "Negative port numbers are not allowed: " + port);
           }
           return port;
         }
+
+        case SQLITE_DATABASE_FILE:
+          return new File(params.get(0));
 
         default:
           throw new IllegalArgumentException(

--- a/src/main/java/com/senzing/poc/services/CountStatsServices.java
+++ b/src/main/java/com/senzing/poc/services/CountStatsServices.java
@@ -1,7 +1,11 @@
 package com.senzing.poc.services;
 
+import java.util.Set;
+import java.util.Map;
+import java.util.LinkedHashMap;
 import java.sql.Connection;
 import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import javax.ws.rs.*;
@@ -11,6 +15,7 @@ import javax.ws.rs.core.UriInfo;
 import com.senzing.poc.model.SzCountStats;
 import com.senzing.poc.model.SzSourceCountStats;
 import com.senzing.poc.model.SzCountStatsResponse;
+import com.senzing.poc.model.SzSourceCountStatsResponse;
 import com.senzing.poc.server.SzPocProvider;
 import com.senzing.api.services.ServicesSupport;
 import com.senzing.util.AccessToken;
@@ -19,19 +24,20 @@ import com.senzing.api.model.SzHttpMethod;
 
 import static com.senzing.sql.SQLUtilities.*;
 import static com.senzing.api.model.SzHttpMethod.POST;
-import static com.senzing.util.LoggingUtilities.logOnceAndThrow;
+import static com.senzing.util.LoggingUtilities.*;
 import static javax.ws.rs.core.MediaType.*;
 import static com.senzing.api.model.SzHttpMethod.GET;
 
 /**
- * Bulk Data REST services.
+ * Count Statistics REST services.
  */
 @Path("/statistics/counts")
 @Produces(APPLICATION_JSON)
 public class CountStatsServices implements DataMartServicesSupport {
   /**
-   * Gets all the count stats including record counts, entity counts and 
-   * a breakdown by data source.
+   * Gets all the count stats including total record count, total entity
+   * count and total unmatched record count along with a breakdown of 
+   * record count, entity count and unmatched record count by data source.
    *
    * @param uriInfo The {@link UriInfo} for the request.
    */
@@ -42,81 +48,7 @@ public class CountStatsServices implements DataMartServicesSupport {
     SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
     Timers        timers    = this.newTimers();
     try {
-        SzCountStats stats = this.getStatistics(true, // include entity counts
-                                                true, // include record counts
-                                                GET, 
-                                                uriInfo, 
-                                                timers, 
-                                                provider);
-
-        return SzCountStatsResponse.FACTORY.create(this.newMeta(GET, 200, timers),
-                                                   this.newLinks(uriInfo),
-                                                   stats);
-        
-    } catch (ClientErrorException e) {
-      throw e;
-
-    } catch (WebApplicationException e) {
-      throw logOnceAndThrow(e);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
-    }
-  }
-
-  /**
-   * Gets all the entity count stats including with a break down
-   * by data source.
-   *
-   * @param uriInfo The {@link UriInfo} for the request.
-   */
-  @GET
-  @Path("/entities")
-  public SzCountStatsResponse getEntityCountStatistics(@Context UriInfo uriInfo)
-  {
-    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
-    Timers        timers    = this.newTimers();
-    try {
-        SzCountStats stats = this.getStatistics(true,   // include entity counts
-                                                false,  // exclude record counts
-                                                GET, 
-                                                uriInfo, 
-                                                timers, 
-                                                provider);
-
-        return SzCountStatsResponse.FACTORY.create(this.newMeta(GET, 200, timers),
-                                                   this.newLinks(uriInfo),
-                                                   stats);
-        
-    } catch (ClientErrorException e) {
-      throw e;
-
-    } catch (WebApplicationException e) {
-      throw logOnceAndThrow(e);
-
-    } catch (Exception e) {
-      e.printStackTrace();
-      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
-    }
-  }
-
-  /**
-   * Gets all the record count stats including with a break down
-   * by data source.
-   *
-   * @param uriInfo The {@link UriInfo} for the request.
-   */
-  @GET
-  @Path("/records")
-  public SzCountStatsResponse getRecordCountStatistics(@Context UriInfo uriInfo)
-  {
-    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
-    Timers        timers    = this.newTimers();
-    try {
-        SzCountStats stats = this.getStatistics(false,  // exclude entity counts
-                                                true,   // include record counts
-                                                GET, 
+        SzCountStats stats = this.getStatistics(GET, 
                                                 uriInfo, 
                                                 timers, 
                                                 provider);
@@ -140,20 +72,18 @@ public class CountStatsServices implements DataMartServicesSupport {
   /**
    * Internal method for obtaining the count statistics.
    * 
-   * @param includeEntityCounts <code>true</code> if entity counts should be
-   *                            included, otherwise <code>false</code>.
-   * @param includeRecordCounts <code>true</code> if record counts should be
-   *                            included, otherwise <code>false</code>.
    * @param httpMethod The {@link SzHttpMethod} of the request.
    * @param uriInfo The {@link UriInfo} for the request.
    * @param timers The {@link Timers} associated with the request.
    * @param provider The {@link SzPocProvider} for the request context.
    * 
    * @return The {@link SzCountStats} describing the statistics.
+   * 
+   * @throws ServiceUnavailableException If the data mart is not yet ready to 
+   *                                     service a request.
+   * @throws InternalServerErrorException If an internal error occurs.
    */
-  protected SzCountStats getStatistics(boolean          includeEntityCounts,
-                                       boolean          includeRecordCounts,
-                                       SzHttpMethod     httpMethod,
+  protected SzCountStats getStatistics(SzHttpMethod     httpMethod,
                                        UriInfo          uriInfo,
                                        Timers           timers,
                                        SzPocProvider    provider)
@@ -168,26 +98,28 @@ public class CountStatsServices implements DataMartServicesSupport {
       // get the connection to the data mart database
       conn = this.getConnection(httpMethod, uriInfo, timers, provider);
       stmt = conn.createStatement();
-      
-      // check if getting the entity counts
-      if (includeEntityCounts) {
-        this.queryingDatabase(timers, "selectEntityCount");
-        try {
-          // prepare the total entity count query
-          rs = stmt.executeQuery(
-            "SELECT SUM(entity_count) FROM sz_dm_report WHERE report='ESB'");
-          
-          // read the results
-          rs.next();
-          result.setTotalEntityCount(rs.getLong(1));
 
-        } finally {
-          this.queriedDatabase(timers, "selectEntityCount");
-          // release resources
-          rs = close(rs);
-        }
+      // get the total entity count
+      this.queryingDatabase(timers, "selectEntityCount");
+      try {
+        // prepare the total entity count query
+        rs = stmt.executeQuery(
+          "SELECT SUM(entity_count) FROM sz_dm_report WHERE report='ESB'");
+          
+        // read the results
+        rs.next();
+        result.setTotalEntityCount(rs.getLong(1));
+
+      } finally {
+        this.queriedDatabase(timers, "selectEntityCount");
+        // release resources
+        rs = close(rs);
       }
 
+      // create a map to keep track of the source stats
+      Map<String, SzSourceCountStats> sourceStatsMap = new LinkedHashMap<>();
+
+      // now get the source entity and record counts
       long totalRecordCount = 0L;
 
       this.queryingDatabase(timers, "selectCountsBySource");
@@ -195,7 +127,8 @@ public class CountStatsServices implements DataMartServicesSupport {
         // now get the counts by data source
         rs = stmt.executeQuery(
           "SELECT data_source1, entity_count, record_count "
-          + "FROM sz_dm_report WHERE report='DSS' AND statistic='ENTITY_COUNT'");
+          + "FROM sz_dm_report WHERE report='DSS' AND statistic='ENTITY_COUNT' "
+          + "ORDER BY data_source1");
 
         while (rs.next()) {
           String  dataSource  = rs.getString(1);
@@ -206,10 +139,10 @@ public class CountStatsServices implements DataMartServicesSupport {
           totalRecordCount += recordCount;
 
           SzSourceCountStats stats = SzSourceCountStats.FACTORY.create(dataSource);
-          if (includeEntityCounts) stats.setEntityCount(entityCount);
-          if (includeRecordCounts) stats.setRecordCount(recordCount);
+          stats.setEntityCount(entityCount);
+          stats.setRecordCount(recordCount);
 
-          result.addDataSourceCount(stats);
+          sourceStatsMap.put(dataSource, stats);
         }
 
       } finally {
@@ -219,11 +152,57 @@ public class CountStatsServices implements DataMartServicesSupport {
       // release resources
       rs = close(rs);
 
-      // optionally set the total record count
-      if (includeRecordCounts) {
-        result.setTotalRecordCount(totalRecordCount);
+      // set the total record count
+      result.setTotalRecordCount(totalRecordCount);
+
+      long totalUnmatchedRecordCount = 0L;
+
+      this.queryingDatabase(timers, "selectUnmatchedCountsBySource");
+      try {
+        // now get the counts by data source
+        rs = stmt.executeQuery(
+          "SELECT data_source1, entity_count "
+          + "FROM sz_dm_report WHERE report='DSS' AND statistic='UNMATCHED_COUNT' "
+          + "ORDER BY data_source1");
+
+        while (rs.next()) {
+          String  dataSource      = rs.getString(1);
+          long    unmatchedCount  = rs.getLong(2);
+
+          // increment the total record count
+          totalUnmatchedRecordCount += unmatchedCount;
+
+          SzSourceCountStats stats = sourceStatsMap.remove(dataSource);
+          if (stats == null) {
+            stats = SzSourceCountStats.FACTORY.create(dataSource);
+            logWarning("Missing entity and record count stats for data source, "
+                       + "but got unmatched record count stats: " + dataSource);
+          }
+
+          // set the unmatched record count
+          stats.setUnmatchedRecordCount(unmatchedCount);
+
+          // add the source stats to the result
+          result.addDataSourceCount(stats);          
+        }
+
+      } finally {
+        this.queriedDatabase(timers, "selectCountsBySource");
       }
-      
+
+      // release resources
+      rs = close(rs);
+
+      // set the total unmatched record count
+      result.setTotalUnmatchedRecordCount(totalUnmatchedRecordCount);
+
+      // add the source stats to the result
+      sourceStatsMap.values().forEach(stats -> {
+        logWarning("Missing unmatched record count stats for data source, but "
+                   + "got entity and record count stats: " + stats.getDataSourceCode());
+        result.addDataSourceCount(stats);
+      });
+
       // return the result
       return result;
 
@@ -234,6 +213,168 @@ public class CountStatsServices implements DataMartServicesSupport {
     } finally {
       rs   = close(rs);
       stmt = close(stmt);
+      conn = close(conn);
+    }
+  }
+
+  /**
+   * Gets all the count stats for a specific data source including record 
+   * counts, entity counts and unmatched record counts for that data source.
+   *
+   * @param dataSourceCode The data source code identifying the data source
+   *                       for which the count statistics are being requested.
+   * @param uriInfo The {@link UriInfo} for the request.
+   */
+  @GET
+  @Path("/data-sources/{dataSourceCode}")
+  public SzSourceCountStatsResponse getSourceCountStatistics(
+    @PathParam("dataSourceCode") String dataSourceCode,
+    @Context UriInfo uriInfo)
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+    try {
+        SzSourceCountStats stats = this.getSourceStatistics(dataSourceCode, 
+                                                            GET, 
+                                                            uriInfo, 
+                                                            timers, 
+                                                            provider);
+
+        return SzSourceCountStatsResponse.FACTORY.create(
+          this.newMeta(GET, 200, timers),
+          this.newLinks(uriInfo),
+          stats);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+  /**
+   * Internal method for obtaining the count statistics for a specific
+   * data source.
+   * 
+   * @param dataSource The data source code for which the statistics
+   *                   are being requested.
+   * @param httpMethod The {@link SzHttpMethod} of the request.
+   * @param uriInfo The {@link UriInfo} for the request.
+   * @param timers The {@link Timers} associated with the request.
+   * @param provider The {@link SzPocProvider} for the request context.
+   * 
+   * @return The {@link SzCountStats} describing the statistics.
+   * 
+   * @throws NotFoundException If the specified data source is not recognized.
+   * @throws ServiceUnavailableException If the data mart is not yet ready to 
+   *                                     service a request.
+   * @throws InternalServerErrorException If an internal error occurs.
+   */
+  protected SzSourceCountStats getSourceStatistics(
+    String            dataSource,
+    SzHttpMethod      httpMethod,
+    UriInfo           uriInfo,
+    Timers            timers,
+    SzPocProvider     provider)
+      throws ServiceUnavailableException, NotFoundException, 
+             InternalServerErrorException
+  {
+    // check the data source
+    Set<String> dataSources = provider.getDataSources(dataSource);
+    if (!dataSources.contains(dataSource)) {
+      throw new NotFoundException("Unrecognized data source: " + dataSource);
+    }
+
+    // get the connection
+    Connection          conn    = null;
+    PreparedStatement   ps      = null;
+    ResultSet           rs      = null;
+    SzSourceCountStats  result  = SzSourceCountStats.FACTORY.create(dataSource);
+    try {
+      this.queryingDatabase(timers, "selectCountsForSource");
+      try {
+        // prepare the statement
+        ps = conn.prepareStatement(
+          "SELECT entity_count, record_count "
+          + "FROM sz_dm_report WHERE report='DSS' AND statistic='ENTITY_COUNT' "
+          + "AND data_source1 = ?");
+
+        // bind the parameters
+        ps.setString(1, dataSource);
+
+        // execute the query
+        rs = ps.executeQuery();
+        
+        // check if we have a result
+        if (rs.next()) {
+          long    entityCount = rs.getLong(1);
+          long    recordCount = rs.getLong(2);
+
+          result.setEntityCount(entityCount);
+          result.setRecordCount(recordCount);
+
+        } else {
+          logWarning("Failed to find entity and record count stats "
+                     + "for data source: " + dataSource);
+        }
+
+      } finally {
+        this.queriedDatabase(timers, "selectCountsForSource");
+      }
+
+      // release resources
+      rs = close(rs);
+      ps = close(ps);
+
+      boolean foundUnmatched = false;
+      this.queryingDatabase(timers, "selectUnmatchedCountForSource");
+      try {
+        // now get the counts by data source
+        ps = conn.prepareStatement(
+          "SELECT entity_count "
+          + "FROM sz_dm_report WHERE report='DSS' AND statistic='UNMATCHED_COUNT' "
+          + "AND data_source1 = ?");
+
+        // bind the parameters
+        ps.setString(1, dataSource);
+
+        // execute the query
+        rs = ps.executeQuery();
+        if (rs.next()) {
+          foundUnmatched = true;
+          long unmatchedCount = rs.getLong(1);
+
+          // set the unmatched record count
+          result.setUnmatchedRecordCount(unmatchedCount);
+
+        } else {
+          logWarning("Failed to find unmatched record count stats "
+                     + "for data source: " + dataSource);
+        }
+
+      } finally {
+        this.queriedDatabase(timers, "selectCountsForSource");
+      }
+
+      // release resources
+      rs = close(rs);
+      ps = close(ps);
+
+      // return the result
+      return result;
+
+    } catch (SQLException e) {
+      throw this.newInternalServerErrorException(
+        httpMethod, uriInfo, timers, e);
+
+    } finally {
+      rs   = close(rs);
+      ps   = close(ps);
       conn = close(conn);
     }
   }

--- a/src/main/java/com/senzing/poc/services/CountStatsServices.java
+++ b/src/main/java/com/senzing/poc/services/CountStatsServices.java
@@ -296,6 +296,9 @@ public class CountStatsServices implements DataMartServicesSupport {
     ResultSet           rs      = null;
     SzSourceCountStats  result  = SzSourceCountStats.FACTORY.create(dataSource);
     try {
+      // get the connection to the data mart database
+      conn = this.getConnection(httpMethod, uriInfo, timers, provider);
+      
       this.queryingDatabase(timers, "selectCountsForSource");
       try {
         // prepare the statement

--- a/src/main/java/com/senzing/poc/services/CountStatsServices.java
+++ b/src/main/java/com/senzing/poc/services/CountStatsServices.java
@@ -1,0 +1,240 @@
+package com.senzing.poc.services;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import com.senzing.poc.model.SzCountStats;
+import com.senzing.poc.model.SzSourceCountStats;
+import com.senzing.poc.model.SzCountStatsResponse;
+import com.senzing.poc.server.SzPocProvider;
+import com.senzing.api.services.ServicesSupport;
+import com.senzing.util.AccessToken;
+import com.senzing.util.Timers;
+import com.senzing.api.model.SzHttpMethod;
+
+import static com.senzing.sql.SQLUtilities.*;
+import static com.senzing.api.model.SzHttpMethod.POST;
+import static com.senzing.util.LoggingUtilities.logOnceAndThrow;
+import static javax.ws.rs.core.MediaType.*;
+import static com.senzing.api.model.SzHttpMethod.GET;
+
+/**
+ * Bulk Data REST services.
+ */
+@Path("/statistics/counts")
+@Produces(APPLICATION_JSON)
+public class CountStatsServices implements DataMartServicesSupport {
+  /**
+   * Gets all the count stats including record counts, entity counts and 
+   * a breakdown by data source.
+   *
+   * @param uriInfo The {@link UriInfo} for the request.
+   */
+  @GET
+  @Path("/")
+  public SzCountStatsResponse getCountStatistics(@Context UriInfo uriInfo)
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+    try {
+        SzCountStats stats = this.getStatistics(true, // include entity counts
+                                                true, // include record counts
+                                                GET, 
+                                                uriInfo, 
+                                                timers, 
+                                                provider);
+
+        return SzCountStatsResponse.FACTORY.create(this.newMeta(GET, 200, timers),
+                                                   this.newLinks(uriInfo),
+                                                   stats);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+  /**
+   * Gets all the entity count stats including with a break down
+   * by data source.
+   *
+   * @param uriInfo The {@link UriInfo} for the request.
+   */
+  @GET
+  @Path("/entities")
+  public SzCountStatsResponse getEntityCountStatistics(@Context UriInfo uriInfo)
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+    try {
+        SzCountStats stats = this.getStatistics(true,   // include entity counts
+                                                false,  // exclude record counts
+                                                GET, 
+                                                uriInfo, 
+                                                timers, 
+                                                provider);
+
+        return SzCountStatsResponse.FACTORY.create(this.newMeta(GET, 200, timers),
+                                                   this.newLinks(uriInfo),
+                                                   stats);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+  /**
+   * Gets all the record count stats including with a break down
+   * by data source.
+   *
+   * @param uriInfo The {@link UriInfo} for the request.
+   */
+  @GET
+  @Path("/records")
+  public SzCountStatsResponse getRecordCountStatistics(@Context UriInfo uriInfo)
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+    try {
+        SzCountStats stats = this.getStatistics(false,  // exclude entity counts
+                                                true,   // include record counts
+                                                GET, 
+                                                uriInfo, 
+                                                timers, 
+                                                provider);
+
+        return SzCountStatsResponse.FACTORY.create(this.newMeta(GET, 200, timers),
+                                                   this.newLinks(uriInfo),
+                                                   stats);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+  /**
+   * Internal method for obtaining the count statistics.
+   * 
+   * @param includeEntityCounts <code>true</code> if entity counts should be
+   *                            included, otherwise <code>false</code>.
+   * @param includeRecordCounts <code>true</code> if record counts should be
+   *                            included, otherwise <code>false</code>.
+   * @param httpMethod The {@link SzHttpMethod} of the request.
+   * @param uriInfo The {@link UriInfo} for the request.
+   * @param timers The {@link Timers} associated with the request.
+   * @param provider The {@link SzPocProvider} for the request context.
+   * 
+   * @return The {@link SzCountStats} describing the statistics.
+   */
+  protected SzCountStats getStatistics(boolean          includeEntityCounts,
+                                       boolean          includeRecordCounts,
+                                       SzHttpMethod     httpMethod,
+                                       UriInfo          uriInfo,
+                                       Timers           timers,
+                                       SzPocProvider    provider)
+      throws ServiceUnavailableException, InternalServerErrorException
+  {
+    // get the connection
+    Connection    conn    = null;
+    Statement     stmt    = null;
+    ResultSet     rs      = null;
+    SzCountStats  result  = SzCountStats.FACTORY.create();
+    try {
+      // get the connection to the data mart database
+      conn = this.getConnection(httpMethod, uriInfo, timers, provider);
+      stmt = conn.createStatement();
+      
+      // check if getting the entity counts
+      if (includeEntityCounts) {
+        this.queryingDatabase(timers, "selectEntityCount");
+        try {
+          // prepare the total entity count query
+          rs = stmt.executeQuery(
+            "SELECT SUM(entity_count) FROM sz_dm_report WHERE report='ESB'");
+          
+          // read the results
+          rs.next();
+          result.setTotalEntityCount(rs.getLong(1));
+
+        } finally {
+          this.queriedDatabase(timers, "selectEntityCount");
+          // release resources
+          rs = close(rs);
+        }
+      }
+
+      long totalRecordCount = 0L;
+
+      this.queryingDatabase(timers, "selectCountsBySource");
+      try {
+        // now get the counts by data source
+        rs = stmt.executeQuery(
+          "SELECT data_source1, entity_count, record_count "
+          + "FROM sz_dm_report WHERE report='DSS' AND statistic='ENTITY_COUNT'");
+
+        while (rs.next()) {
+          String  dataSource  = rs.getString(1);
+          long    entityCount = rs.getLong(2);
+          long    recordCount = rs.getLong(3);
+
+          // increment the total record count
+          totalRecordCount += recordCount;
+
+          SzSourceCountStats stats = SzSourceCountStats.FACTORY.create(dataSource);
+          if (includeEntityCounts) stats.setEntityCount(entityCount);
+          if (includeRecordCounts) stats.setRecordCount(recordCount);
+
+          result.addDataSourceCount(stats);
+        }
+
+      } finally {
+        this.queriedDatabase(timers, "selectCountsBySource");
+      }
+
+      // release resources
+      rs = close(rs);
+
+      // optionally set the total record count
+      if (includeRecordCounts) {
+        result.setTotalRecordCount(totalRecordCount);
+      }
+      
+      // return the result
+      return result;
+
+    } catch (SQLException e) {
+      throw this.newInternalServerErrorException(
+        httpMethod, uriInfo, timers, e);
+
+    } finally {
+      rs   = close(rs);
+      stmt = close(stmt);
+      conn = close(conn);
+    }
+  }
+}

--- a/src/main/java/com/senzing/poc/services/DataMartServicesSupport.java
+++ b/src/main/java/com/senzing/poc/services/DataMartServicesSupport.java
@@ -1,7 +1,12 @@
 package com.senzing.poc.services;
 
+import java.util.List;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.UriInfo;
@@ -10,8 +15,13 @@ import com.senzing.util.Timers;
 import com.senzing.api.services.ServicesSupport;
 import com.senzing.api.model.SzHttpMethod;
 import com.senzing.poc.server.SzPocProvider;
+import com.senzing.poc.model.SzBoundType;
+import com.senzing.poc.model.SzEntitiesPage;
 import com.senzing.datamart.SzReplicationProvider;
 import com.senzing.sql.ConnectionProvider;
+
+import static com.senzing.poc.model.SzBoundType.*;
+import static com.senzing.sql.SQLUtilities.*;
 
 /**
  * Extends {@link ServicesSupport} to add additional functionality 
@@ -143,5 +153,158 @@ public interface DataMartServicesSupport extends ServicesSupport {
 
         // return the provider
         return replicationProvider;
+    }
+
+    /**
+     * Retrieves a page of entity ID's for a specific report key with the
+     * specified bound applied.
+     * 
+     * @param reportKey The report key identifying the report with which the 
+     *                  entity ID's are associated.
+     * @param entityIdBound The bounded value for the returned entity ID's.
+     * @param boundType The {@link SzBoundType} describing how the entity ID
+     *                  bound value is applied in retrieving the page.
+     * @param pageSize The maximum number of entity ID's to return.
+     * 
+     * @throws BadRequestException If the specified page size is less than one (1).
+     * @throws ServiceUnavailableException If the {@link SzReplicationProvider} is not yet
+     *                                     ready to use after waiting {@link 
+     *                                     #REPLICATION_READY_WAIT_TIME} milliseconds.
+     * @throws InternalServerErrorException If the {@link SzReplicationProvider} indicates that
+     *                                      it will never be ready to use.
+     */
+    default SzEntitiesPage retrieveEntitiesPage(SzHttpMethod    httpMethod,
+                                                UriInfo         uriInfo,
+                                                Timers          timers,
+                                                SzPocProvider   provider,
+                                                String          reportKey, 
+                                                long            entityIdBound,
+                                                SzBoundType     boundType, 
+                                                int             pageSize) 
+        throws BadRequestException,
+               ServiceUnavailableException, 
+               InternalServerErrorException                                              
+    {
+        // check the request parameters
+        if (pageSize < 1) {
+            throw this.newBadRequestException(httpMethod, uriInfo, timers, 
+                "The specified page size must be a positive integer: " + pageSize);
+        }
+
+        // check if the bound type is null (this should not be the case)
+        if (boundType == null) boundType = EXCLUSIVE_LOWER;
+
+        // prepare the result object the rest of the page
+        SzEntitiesPage page = SzEntitiesPage.FACTORY.create();
+        page.setBound(entityIdBound);
+        page.setBoundType(boundType);
+        page.setPageSize(pageSize);
+
+        // setup the JDBC variables
+        Connection          conn    = null;
+        PreparedStatement   ps      = null;
+        ResultSet           rs      = null;
+        try {
+            // get the connection to the database
+            conn = this.getConnection(httpMethod, uriInfo, timers, provider);
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("SELECT entity_id FROM sz_dm_report_detail "
+                      + "WHERE report_key = ? AND related_id = 0 AND entity_id ");
+
+            // handle the operator and order-by for the bound type
+            switch (boundType) {
+                case INCLUSIVE_LOWER:
+                    sb.append(" >= ? ORDER BY entity_id ASC ");
+                    break;
+                case EXCLUSIVE_LOWER:
+                    sb.append(" > ? ORDER BY entity_id ASC ");
+                    break;
+                case INCLUSIVE_UPPER:
+                    sb.append(" <= ? ORDER BY entity_id DESC ");
+                    break;
+                case EXCLUSIVE_UPPER:
+                    sb.append(" < ? ORDER BY entity_id DESC ");
+                    break;
+                default:
+                    throw new IllegalStateException("Unhandled bound type: " + boundType);
+            }
+
+            // handle the page size
+            sb.append("LIMIT ?");
+
+            // prepare the statement
+            ps = conn.prepareStatement(sb.toString());
+
+            // bind the parameters
+            ps.setString(1, reportKey);
+            ps.setLong(2, entityIdBound);
+            ps.setInt(3, pageSize);
+
+            // execute the query
+            rs = ps.executeQuery();
+
+            // read the results
+            while (rs.next()) {
+                page.addEntityId(rs.getLong(1));
+            }
+
+            // release resources
+            rs = close(rs);
+            ps = close(ps);
+
+            // now get the total entity ID count
+            long totalCount = 0L;
+            ps = conn.prepareStatement("SELECT COUNT(*) FROM sz_dm_report_detail WHERE report_key = ?");
+            ps.setString(1, reportKey);
+            rs = ps.executeQuery();
+            rs.next();
+            totalCount = rs.getLong(1);
+            rs = close(rs);
+            ps = close(ps);
+
+            // now get the "before" and "after" entity ID count
+            long beforeCount    = 0L;
+            long afterCount     = 0L;
+            List<Long> entityIds = page.getEntityIds();
+            if (entityIds.size() > 0) {
+                ps = conn.prepareStatement
+                    ("SELECT COUNT(*) FROM sz_dm_report_detail "
+                    + "WHERE report_key = ? AND entity_id < ?");
+                
+                ps.setString(1, reportKey);
+                ps.setLong(2, entityIds.get(0));
+
+                rs = ps.executeQuery();
+                rs.next();
+                
+                beforeCount = rs.getLong(1);
+
+                rs = close(rs);
+                ps = close(ps);
+            }
+            // calculate the "after" count from total, page and before count
+            afterCount = totalCount - entityIds.size() - beforeCount;
+
+            // set the fields on the page
+            page.setTotalEntityCount(totalCount);
+            page.setBeforeEntityCount(beforeCount);
+            page.setAfterEntityCount(afterCount);
+
+            // return the page
+            return page;
+
+        } catch (WebApplicationException e) {
+            throw e;
+
+        } catch (Exception e) {
+            throw this.newInternalServerErrorException(
+                httpMethod, uriInfo, timers, e);
+
+        } finally {
+            rs = close(rs);
+            ps = close(ps);
+            conn = close(conn);
+        }
     }
 }

--- a/src/main/java/com/senzing/poc/services/DataMartServicesSupport.java
+++ b/src/main/java/com/senzing/poc/services/DataMartServicesSupport.java
@@ -1,0 +1,147 @@
+package com.senzing.poc.services;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.core.UriInfo;
+
+import com.senzing.util.Timers;
+import com.senzing.api.services.ServicesSupport;
+import com.senzing.api.model.SzHttpMethod;
+import com.senzing.poc.server.SzPocProvider;
+import com.senzing.datamart.SzReplicationProvider;
+import com.senzing.sql.ConnectionProvider;
+
+/**
+ * Extends {@link ServicesSupport} to add additional functionality 
+ * specific to the data mart replicator services.
+ */
+public interface DataMartServicesSupport extends ServicesSupport {
+    /**
+     * The number of milliseconds to wait for the data mart replicator
+     * to become ready before throwing a {@link ServiceUnavailableException}.
+     */
+    long REPLICATOR_READY_WAIT_TIME = 10000L;
+
+    /**
+     * The standardized {@link Timers} key used for SQL queries. 
+     */
+    String DATABASE_QUERY_TIMING = "sqlQuery";
+
+    /**
+     * Transitions the specified {@link Timers} into the {@link
+     * #DATABASE_QUERY_TIMING} stage.
+     *
+     * @param timers The {@link Timers} instance to transition.
+     * @param queryDescription A description of the query being executed.
+     */
+    default void queryingDatabase(Timers timers, String queryDescription) {
+        if (timers == null) return;
+        timers.start(DATABASE_QUERY_TIMING,
+                     DATABASE_QUERY_TIMING + ":" + queryDescription);
+    }
+
+    /**
+     * Concludes the {@link #DATABASE_QUERY_TIMING} stage for the specified
+     * {@link Timers}.
+     *
+     * @param timers   The {@link Timers} instance to transition.
+     * @param queryDescription A description of the query being executed.
+     */
+    default void queriedDatabase(Timers timers, String queryDescription) {
+        if (timers == null) return;
+        timers.pause(DATABASE_QUERY_TIMING,
+                     DATABASE_QUERY_TIMING + ":" + queryDescription);
+    }
+
+    /**
+     * Gets the {@link Connection} from the underlying {@link SzReplicationProvider}
+     * for use in accessing the data mart.  The caller must call {@link #close()} on
+     * this {@link Connection} when done using it in order to make it available for
+     * other use by other operations.
+     * 
+     * @param httpMethod The {@link SzHttpMethod} of the request.
+     * @param uriInfo The {@link UriInfo} for the request.
+     * @param timers The {@link Timers} for the request.
+     * @param provider The {@link SzPocProvider} associated with the request.
+     * 
+     * @return The {@link SzReplicationProvider} that was obtained.
+     * 
+     * @throws SQLException If there is a failure in obtaining the {@link Connection}
+     *                      from the underlying {@link SzReplicationProvider}.
+     * 
+     * @throws ServiceUnavailableException If the {@link SzReplicationProvider} is not yet
+     *                                     ready to use after waiting {@link 
+     *                                     #REPLICATION_READY_WAIT_TIME} milliseconds.
+     * @throws InternalServerErrorException If the {@link SzReplicationProvider} indicates that
+     *                                      it will never be ready to use.
+     */
+    default Connection getConnection(SzHttpMethod   httpMethod,
+                                     UriInfo        uriInfo,
+                                     Timers         timers,
+                                     SzPocProvider  provider) 
+        throws SQLException, ServiceUnavailableException, InternalServerErrorException
+    {
+        SzReplicationProvider repProvider 
+            = this.getReplicationProvider(httpMethod, uriInfo, timers, provider);
+
+        ConnectionProvider connProvider = repProvider.getConnectionProvider();
+
+        return connProvider.getConnection();
+    }
+
+    /**
+     * Gets the {@link SzReplicationProvider} from the specified {@link SzPocProvider}
+     * and ensures it is ready to use before returning it.  This will wait at most
+     * {@link #REPLICATOR_READY_WAIT_TIME} milliseconds for the replicator to become
+     * ready to use.
+     * 
+     * @param httpMethod The {@link SzHttpMethod} of the request.
+     * @param uriInfo The {@link UriInfo} for the request.
+     * @param timers The {@link Timers} for the request.
+     * @param provider The {@link SzPocProvider} associated with the request.
+     * 
+     * @return The {@link SzReplicationProvider} that was obtained.
+     * 
+     * @throws ServiceUnavailableException If the {@link SzReplicationProvider} is not yet
+     *                                     ready to use after waiting {@link 
+     *                                     #REPLICATION_READY_WAIT_TIME} milliseconds.
+     * @throws InternalServerErrorException If the {@link SzReplicationProvider} indicates that
+     *                                      it will never be ready to use.
+     */
+    default SzReplicationProvider getReplicationProvider(SzHttpMethod   httpMethod,
+                                                         UriInfo        uriInfo,
+                                                         Timers         timers,
+                                                         SzPocProvider  provider) 
+        throws ServiceUnavailableException, InternalServerErrorException
+    {
+        // get the replication provider
+        SzReplicationProvider replicationProvider = provider.getReplicationProvider();
+
+        Boolean ready = null;
+        try {
+            // ensure it is ready
+            ready = replicationProvider.waitUntilReady(REPLICATOR_READY_WAIT_TIME);
+        
+        } catch (InterruptedException e) {
+            throw this.newInternalServerErrorException(
+                httpMethod, uriInfo, timers, e);
+        }
+
+        // check if it will never be ready
+        if (ready == null) {
+            throw this.newInternalServerErrorException(
+                httpMethod, uriInfo, timers, "Data Mart Replicator cannot service requests.");
+        }
+
+        // check if it just is not yet ready
+        if (Boolean.FALSE.equals(ready)) {
+            throw this.newServiceUnavailableErrorException(
+                httpMethod, uriInfo, timers, "Data Mart Replicator is not ready");
+        }
+
+        // return the provider
+        return replicationProvider;
+    }
+}

--- a/src/main/java/com/senzing/poc/services/EntitySizeBreakdownServices.java
+++ b/src/main/java/com/senzing/poc/services/EntitySizeBreakdownServices.java
@@ -34,9 +34,11 @@ import static com.senzing.api.model.SzHttpMethod.GET;
 /**
  * Count Statistics REST services.
  */
-@Path("/statistics/entity-sizes")
+@Path("/statistics/sizes")
 @Produces(APPLICATION_JSON)
-public class EntitySizeServices implements DataMartServicesSupport {
+public class EntitySizeBreakdownServices
+  implements DataMartServicesSupport 
+{
   /**
    * Gets an {@link SzEntitySizeBreakdownResponse} describing the 
    * entity size breakdown which is the number of entities in the
@@ -46,7 +48,7 @@ public class EntitySizeServices implements DataMartServicesSupport {
    * @param uriInfo The {@link UriInfo} for the request.
    */
   @GET
-  @Path("/counts")
+  @Path("/")
   public SzEntitySizeBreakdownResponse getEntitySizeBreakdown(
     @Context UriInfo uriInfo)
   {
@@ -155,7 +157,7 @@ public class EntitySizeServices implements DataMartServicesSupport {
    * @throws NotFoundException If the specified entity size is less than one.
    */
   @GET
-  @Path("/{entitySize}/count")
+  @Path("/{entitySize}")
   public SzEntitySizeCountResponse getEntitySizeCount(
     @PathParam("entitySize")  int     entitySize,
     @Context                  UriInfo uriInfo)

--- a/src/main/java/com/senzing/poc/services/EntitySizeServices.java
+++ b/src/main/java/com/senzing/poc/services/EntitySizeServices.java
@@ -1,0 +1,332 @@
+package com.senzing.poc.services;
+
+import java.util.Set;
+import java.util.Map;
+import java.util.LinkedHashMap;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+
+import com.senzing.poc.model.SzEntitySizeBreakdown;
+import com.senzing.poc.model.SzEntitySizeCount;
+import com.senzing.poc.model.SzEntitiesPage;
+import com.senzing.poc.model.SzEntitySizeBreakdownResponse;
+import com.senzing.poc.model.SzEntitySizeCountResponse;
+import com.senzing.poc.model.SzEntitiesPageResponse;
+import com.senzing.poc.model.SzBoundType;
+import com.senzing.poc.server.SzPocProvider;
+import com.senzing.api.services.ServicesSupport;
+import com.senzing.util.AccessToken;
+import com.senzing.util.Timers;
+import com.senzing.api.model.SzHttpMethod;
+
+import static com.senzing.sql.SQLUtilities.*;
+import static com.senzing.api.model.SzHttpMethod.POST;
+import static com.senzing.util.LoggingUtilities.*;
+import static javax.ws.rs.core.MediaType.*;
+import static com.senzing.api.model.SzHttpMethod.GET;
+
+/**
+ * Count Statistics REST services.
+ */
+@Path("/statistics/entity-sizes")
+@Produces(APPLICATION_JSON)
+public class EntitySizeServices implements DataMartServicesSupport {
+  /**
+   * Gets an {@link SzEntitySizeBreakdownResponse} describing the 
+   * entity size breakdown which is the number of entities in the
+   * entity repository having each distinct entity size that exists
+   * in the entity repository.
+   * 
+   * @param uriInfo The {@link UriInfo} for the request.
+   */
+  @GET
+  @Path("/counts")
+  public SzEntitySizeBreakdownResponse getEntitySizeBreakdown(
+    @Context UriInfo uriInfo)
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+    try {
+        SzEntitySizeBreakdown breakdown = this.getBreakdown(GET, 
+                                                            uriInfo, 
+                                                            timers, 
+                                                            provider);
+
+        return SzEntitySizeBreakdownResponse.FACTORY.create(this.newMeta(GET, 200, timers),
+                                                            this.newLinks(uriInfo),
+                                                            breakdown);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+  /**
+   * Internal method for obtaining the entity size breakdown statistics.
+   * 
+   * @param httpMethod The {@link SzHttpMethod} of the request.
+   * @param uriInfo The {@link UriInfo} for the request.
+   * @param timers The {@link Timers} associated with the request.
+   * @param provider The {@link SzPocProvider} for the request context.
+   * 
+   * @return The {@link SzCountStats} describing the statistics.
+   * 
+   * @throws ServiceUnavailableException If the data mart is not yet ready to 
+   *                                     service a request.
+   * @throws InternalServerErrorException If an internal error occurs.
+   */
+  protected SzEntitySizeBreakdown getBreakdown(SzHttpMethod   httpMethod,
+                                               UriInfo        uriInfo,
+                                               Timers         timers,
+                                               SzPocProvider  provider)
+      throws ServiceUnavailableException, InternalServerErrorException
+  {
+    // get the connection
+    Connection  conn  = null;
+    Statement   stmt  = null;
+    ResultSet   rs    = null;
+
+    SzEntitySizeBreakdown result = SzEntitySizeBreakdown.FACTORY.create();
+    try {
+      // get the connection to the data mart database
+      conn = this.getConnection(httpMethod, uriInfo, timers, provider);
+      stmt = conn.createStatement();
+
+      // get the total entity count
+      this.queryingDatabase(timers, "selectEntitySizeBreakdown");
+      try {
+        // prepare the total entity count query
+        rs = stmt.executeQuery(
+          "SELECT statistic, entity_count FROM sz_dm_report WHERE report='ESB'");
+        
+        // read the results
+        while (rs.next()) {
+          SzEntitySizeCount sizeCount = SzEntitySizeCount.FACTORY.create();
+          String  stat  = rs.getString(1);
+          long    count = rs.getLong(2);
+          int     size  = Integer.parseInt(stat);
+
+          sizeCount.setEntitySize(size);
+          sizeCount.setEntityCount(count);
+
+          result.addEntitySizeCount(sizeCount);
+        }
+
+
+      } finally {
+        this.queriedDatabase(timers, "selectEntitySizeBreakdown");
+      }
+
+      // return the result
+      return result;
+
+    } catch (SQLException e) {
+      throw this.newInternalServerErrorException(
+        httpMethod, uriInfo, timers, e);
+
+    } finally {
+      rs   = close(rs);
+      stmt = close(stmt);
+      conn = close(conn);
+    }
+  }
+
+  /**
+   * Gets all the count stats for a specific data source including record 
+   * counts, entity counts and unmatched record counts for that data source.
+   *
+   * @param dataSourceCode The data source code identifying the data source
+   *                       for which the count statistics are being requested.
+   * @param uriInfo The {@link UriInfo} for the request.
+   * 
+   * @throws NotFoundException If the specified entity size is less than one.
+   */
+  @GET
+  @Path("/{entitySize}/count")
+  public SzEntitySizeCountResponse getEntitySizeCount(
+    @PathParam("entitySize")  int     entitySize,
+    @Context                  UriInfo uriInfo)
+    throws NotFoundException
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+
+    // check the entity size
+    if (entitySize < 1) {
+      throw this.newNotFoundException(GET, uriInfo, timers, 
+        "The entity size cannot be less than one: " + entitySize);
+    }
+    
+    try {
+        SzEntitySizeCount sizeCount = this.doGetEntitySizeCount(entitySize,
+                                                                GET, 
+                                                                uriInfo, 
+                                                                timers, 
+                                                                provider);
+
+        return SzEntitySizeCountResponse.FACTORY.create(
+          this.newMeta(GET, 200, timers),
+          this.newLinks(uriInfo),
+          sizeCount);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+  /**
+   * Internal method for obtaining the count statistics for a specific
+   * entity size.
+   * 
+   * @param entitySize The entity size for which the count is being requested.
+   * @param httpMethod The {@link SzHttpMethod} of the request.
+   * @param uriInfo The {@link UriInfo} for the request.
+   * @param timers The {@link Timers} associated with the request.
+   * @param provider The {@link SzPocProvider} for the request context.
+   * 
+   * @return The {@link SzEntitySizeCount} describing the statistics.
+   * 
+   * @throws ServiceUnavailableException If the data mart is not yet ready to 
+   *                                     service a request.
+   * @throws InternalServerErrorException If an internal error occurs.
+   */
+  protected SzEntitySizeCount doGetEntitySizeCount(
+    int               entitySize,
+    SzHttpMethod      httpMethod,
+    UriInfo           uriInfo,
+    Timers            timers,
+    SzPocProvider     provider)
+      throws ServiceUnavailableException,
+             InternalServerErrorException
+  {
+    // get the connection
+    Connection          conn    = null;
+    PreparedStatement   ps      = null;
+    ResultSet           rs      = null;
+    SzEntitySizeCount   result  = SzEntitySizeCount.FACTORY.create();
+
+    result.setEntitySize(entitySize);
+    try {
+      // get the connection to the data mart database
+      conn = this.getConnection(httpMethod, uriInfo, timers, provider);
+
+      this.queryingDatabase(timers, "selectCountForEntitySize");
+      try {
+        // prepare the statement
+        ps = conn.prepareStatement(
+          "SELECT entity_count FROM sz_dm_report "
+          + "WHERE report='ESB' AND statistic=?");
+
+        // bind the parameters
+        ps.setString(1, String.valueOf(entitySize));
+
+        // execute the query
+        rs = ps.executeQuery();
+        
+        // check if we have a result
+        if (rs.next()) {
+          long entityCount = rs.getLong(1);
+
+          result.setEntityCount(entityCount);
+        } else {
+          result.setEntityCount(0L);
+        }
+
+      } finally {
+        this.queriedDatabase(timers, "selectCountForEntitySize");
+      }
+
+      // return the result
+      return result;
+
+    } catch (SQLException e) {
+      throw this.newInternalServerErrorException(
+        httpMethod, uriInfo, timers, e);
+
+    } finally {
+      rs   = close(rs);
+      ps   = close(ps);
+      conn = close(conn);
+    }
+  }
+
+
+  /**
+   * Retrieves a page of entity ID's that identifies entities having the 
+   * respective entity size.
+   *
+   * @param dataSourceCode The data source code identifying the data source
+   *                       for which the count statistics are being requested.
+   * @param uriInfo The {@link UriInfo} for the request.
+   * 
+   * @throws NotFoundException If the specified entity size is less than one.
+   */
+  @GET
+  @Path("/{entitySize}/entities")
+  public SzEntitiesPageResponse getEntityIdsForEntitySize(
+    @PathParam("entitySize")                                    int         entitySize,
+    @QueryParam("bound")      @DefaultValue("0")                long        entityIdBound,
+    @QueryParam("boundType")  @DefaultValue("EXCLUSIVE_LOWER")  SzBoundType boundType,
+    @QueryParam("pageSize")   @DefaultValue("100")              int         pageSize,
+    @Context UriInfo                                                        uriInfo)
+    throws NotFoundException
+  {
+    SzPocProvider provider  = (SzPocProvider) this.getApiProvider();
+    Timers        timers    = this.newTimers();
+
+    // check the entity size
+    if (entitySize < 1) {
+      throw this.newNotFoundException(GET, uriInfo, timers, 
+        "The entity size cannot be less than one: " + entitySize);
+    }
+    
+    try {
+      String reportKey = "ESB:" + entitySize;
+
+      SzEntitiesPage page = this.retrieveEntitiesPage(GET, 
+                                                      uriInfo, 
+                                                      timers, 
+                                                      provider, 
+                                                      reportKey, 
+                                                      entityIdBound, 
+                                                      boundType, 
+                                                      pageSize);
+
+      return SzEntitiesPageResponse.FACTORY.create(
+        this.newMeta(GET, 200, timers),
+        this.newLinks(uriInfo),
+        page);
+        
+    } catch (ClientErrorException e) {
+      throw e;
+
+    } catch (WebApplicationException e) {
+      throw logOnceAndThrow(e);
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw this.newInternalServerErrorException(GET, uriInfo, timers, e);
+    }
+  }
+
+}

--- a/src/main/java/com/senzing/poc/services/LoadedStatsServices.java
+++ b/src/main/java/com/senzing/poc/services/LoadedStatsServices.java
@@ -31,9 +31,9 @@ import static com.senzing.api.model.SzHttpMethod.GET;
 /**
  * Count Statistics REST services.
  */
-@Path("/statistics/counts")
+@Path("/statistics/loaded")
 @Produces(APPLICATION_JSON)
-public class CountStatsServices implements DataMartServicesSupport {
+public class LoadedStatsServices implements DataMartServicesSupport {
   /**
    * Gets all the count stats including total record count, total entity
    * count and total unmatched record count along with a breakdown of 

--- a/src/main/java/com/senzing/poc/services/PocAdminServices.java
+++ b/src/main/java/com/senzing/poc/services/PocAdminServices.java
@@ -24,6 +24,7 @@ public class PocAdminServices extends AdminServices {
     SzPocServerInfo serverInfo = (SzPocServerInfo)
         super.newServerInfo(provider, activeConfigId);
     serverInfo.setLoadQueueConfigured(pocProvider.hasLoadSink());
+    serverInfo.setInfoQueueConfigured(pocProvider.hasConfiguredInfoSink());
     return serverInfo;
   }
 }

--- a/src/main/resources/com/senzing/poc/server/service-endpoints.properties
+++ b/src/main/resources/com/senzing/poc/server/service-endpoints.properties
@@ -1,3 +1,4 @@
 com.senzing.poc.services.BulkDataStreamServices
 com.senzing.poc.services.PocAdminServices
 com.senzing.poc.services.EntityStreamServices
+com.senzing.poc.services.CountStatsServices

--- a/src/main/resources/com/senzing/poc/server/service-endpoints.properties
+++ b/src/main/resources/com/senzing/poc/server/service-endpoints.properties
@@ -1,5 +1,5 @@
 com.senzing.poc.services.BulkDataStreamServices
 com.senzing.poc.services.PocAdminServices
 com.senzing.poc.services.EntityStreamServices
-com.senzing.poc.services.CountStatsServices
-com.senzing.poc.services.EntitySizeServices
+com.senzing.poc.services.LoadedStatsServices
+com.senzing.poc.services.EntitySizeBreakdownServices

--- a/src/main/resources/com/senzing/poc/server/service-endpoints.properties
+++ b/src/main/resources/com/senzing/poc/server/service-endpoints.properties
@@ -2,3 +2,4 @@ com.senzing.poc.services.BulkDataStreamServices
 com.senzing.poc.services.PocAdminServices
 com.senzing.poc.services.EntityStreamServices
 com.senzing.poc.services.CountStatsServices
+com.senzing.poc.services.EntitySizeServices


### PR DESCRIPTION
- Added integration with embedded Data Mart Replicator
  - Added `data-mart-replicator` submodule
  - Added options to configure data mart database connection 
  - Added initial REST operations for data mart statistics
- Deprecated stream loader integration
  - Marked all command-line options deprecated
  - Stream loader integration to be removed in version 4.0
  - Removed startup requirement for load queue configuration